### PR TITLE
Add greedy variants, eval_match, round-robin tooling, RULES.md, and README updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TEST_CPP    := $(wildcard test/*.cpp)
 RESEARCH_BIN_NAMES := best_hand multi_comb play_probs
 RESEARCH_BINS      := $(addprefix $(BUILD_DIR)/research/,$(RESEARCH_BIN_NAMES))
 
-.PHONY: all clean dirs test_core coordinator generate_data benchmark tablebase_opp1_gen research help
+.PHONY: all clean dirs test_core coordinator generate_data eval_match benchmark tablebase_opp1_gen research help
 
 all: help
 
@@ -29,6 +29,7 @@ help:
 	@echo "  make benchmark            - perf benchmark binary (no Arrow)"
 	@echo "  make coordinator          - coordinator + Parquet objects (needs libarrow)"
 	@echo "  make generate_data        - self-play + Parquet + stats (needs libarrow)"
+	@echo "  make eval_match           - head-to-head evaluation binary (no Arrow)"
 	@echo "  make tablebase_opp1_gen   - build opp-1-card tablebase binary generator (no Arrow)"
 	@echo "  make research             - standalone research/*.cpp -> build/research/"
 	@echo "  make clean"
@@ -128,6 +129,23 @@ $(BIN_DIR)/generate_data: $(GENDATA_OBJS)
 	@echo "✓ $(BIN_DIR)/generate_data"
 
 generate_data: dirs $(BIN_DIR)/generate_data
+
+# ============================================================================
+# bin/eval_match — head-to-head evaluation (no Arrow)
+# ============================================================================
+
+$(BUILD_DIR)/src/datagen/eval_match.o: src/datagen/eval_match.cpp | dirs
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(INCLUDES) -c $< -o $@
+
+EVALMATCH_OBJS := $(CORE_OBJS) \
+                  $(BUILD_DIR)/src/simulation/game_simulator.o \
+                  $(BUILD_DIR)/src/datagen/eval_match.o
+
+$(BIN_DIR)/eval_match: $(EVALMATCH_OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+	@echo "✓ $(BIN_DIR)/eval_match"
+
+eval_match: dirs $(BIN_DIR)/eval_match
 
 # ============================================================================
 # bin/tablebase_opp1_gen — precompute tablebase binary (no Arrow)

--- a/README.md
+++ b/README.md
@@ -8,21 +8,17 @@ A C++ implementation of the Big 2 card game (Shanghainese variant) with AI playe
 
 ## Overview
 
-- Full rule implementation (2-player, 49-card deck)
-- Multi-threaded self-play and Parquet export
+- Full rule implementation for the 2-player variant ([RULES.md](RULES.md); the C++ engine in `src/core/` is the source of truth for this repo)
+- Built-in policies: **random**, **greedy**, and **greedy** variants (`greedy_random`, `greedy_random_pass`, `greedy_no_bomb`) with tunable parameters
+- Multi-threaded self-play and Parquet export (`bin/generate_data`)
+- Head-to-head **evaluation** with paired deals and Wilson confidence intervals (`bin/eval_match`), plus **round-robin** tooling for many players
 - Pluggable feature extraction (game-level and turn-level)
 - Tablebase support for opponent-has-one-card endgames
 - Unit tests (`make test_core`)
 
-## Game Rules
+## Rules
 
-Big 2 is a shedding-type card game. This repo follows the **Shanghainese variant**:
-
-- **Modified deck**: 49 cards (standard 52 minus three 2s and one ace)
-- **2-player format**: 16 cards each, 17 unused
-- **Card ranking**: 3 (lowest) through K, A, 2 (highest)
-- **Combinations**: Singles, doubles, triples, full houses, straights, sister straights, triple straights, bombs
-- **Special rules**: Triple aces count as a bomb; bombs can burn other combinations
+Human-readable rules for the Shanghainese-style 2-player variant are in **[RULES.md](RULES.md)** (combinations, bombs, series scoring, etc.). If anything disagrees with the implementation, treat **`src/core/`** as authoritative for this codebase.
 
 ## Project layout
 
@@ -30,14 +26,15 @@ Big 2 is a shedding-type card game. This repo follows the **Shanghainese variant
 .
 ├── src/              # Engine: core, simulation, players, features, datagen (see src/README.md)
 ├── test/             # Unit tests and perf benchmark source (see test/README.md)
-├── scripts/          # Drivers (e.g. data generation), JSON configs, tablebase precompute source (see scripts/README.md)
+├── scripts/          # Data generation, eval_match / round-robin drivers, JSON configs, tablebase precompute (see scripts/README.md)
 ├── analysis/         # Analyze self-play output, train models, experiments (see analysis/README.md)
 ├── research/         # Exploratory C++/Python; binaries under build/research/ via make research (see research/README.md)
 ├── build/            # Compiled objects and research binaries (gitignored)
-├── bin/              # Main binaries (gitignored)
+├── bin/              # Main binaries (gitignored): generate_data, eval_match, test_core, …
 ├── assets/           # Images for docs
 ├── Makefile
-└── README.md
+├── README.md
+└── RULES.md          # Full game rules (variant description)
 ```
 
 ## Architecture
@@ -47,9 +44,11 @@ Big 2 is a shedding-type card game. This repo follows the **Shanghainese variant
 | `Game` | Full game state (hands, discards, legal moves) |
 | `PartialGame` | Imperfect-information view for a player |
 | `Move` | Encoded moves (472 legal move ids) |
-| `Player` | Abstract policy; `RandomPlayer`, `GreedyPlayer` |
+| `Player` | Abstract policy; `RandomPlayer`, `GreedyPlayer`, greedy variants (see `src/players/`) |
+| `player_factory_registry.h` | String → factory for datagen / eval CLIs |
 | `GameSimulator` | one full game |
 | `GameCoordinator` | many games, threaded, writes Parquet |
+| `eval_match` | Pairwise matchups with swapped seats per deal + Wilson CI (`src/datagen/eval_match.cpp`) |
 
 ## Prerequisites
 
@@ -72,6 +71,7 @@ From the **repository root** (directory containing `Makefile`):
 make help              # list targets
 make test_core         # unit tests (no Arrow)
 make benchmark         # perf binary (no Arrow)
+make eval_match        # head-to-head evaluation binary (no Arrow)
 make generate_data     # self-play + Parquet (needs libarrow)
 make tablebase_opp1_gen  # build tablebase precompute tool
 make research          # standalone research/*.cpp -> build/research/
@@ -90,6 +90,21 @@ python3 scripts/generate_data.py scripts/configs/greedy.json --compile
 ```
 
 Writes `<output_path>_game.parquet` and `<output_path>_turn.parquet` when `output_path` and feature lists are set in the config.
+
+Self-play `--player` uses the same policy **names** as evaluation (`random`, `greedy`, `greedy_random`, `greedy_random_pass`, `greedy_no_bomb`, …). The `bin/generate_data` CLI currently instantiates variants with **parameter 0**; use `eval_match` or the round-robin scripts to compare non-zero parameters (see `scripts/README.md`).
+
+## Evaluation (two policies)
+
+`bin/eval_match` runs **paired** games: for each deal, both seats are played so card luck averages out. It prints win counts, a **95% Wilson** interval, and a significance line.
+
+```bash
+make eval_match
+./bin/eval_match --p0 greedy --p1 random --deals 10000 --seed 42
+```
+
+**Convenience:** `scripts/run_eval_match.sh` loads JSON, saves `analysis/eval_match_last.log`, and runs `scripts/analyze_eval_match.py` on the output.
+
+**Round robin:** `scripts/run_round_robin.sh` (or `scripts/round_robin_eval.py`) runs `eval_match` for every unordered pair of players from a JSON list—useful for comparing baselines (`random`, `greedy`) against many variant settings. See `scripts/configs/round_robin_example.json` and `scripts/README.md`.
 
 ## Tablebase
 
@@ -111,13 +126,19 @@ make test_core
 
 ## Python analysis
 
-With `game_features.parquet` / `turn_features.parquet` in the current directory:
+**Parquet reports** (after `generate_data`): with `game_features.parquet` / `turn_features.parquet` in the current directory, or pass paths explicitly:
 
 ```bash
 python3 analysis/analysis.py
 ```
 
+**Eval logs:** summarize a saved `eval_match` transcript:
+
+```bash
+python3 scripts/analyze_eval_match.py --file analysis/eval_match_last.log
+```
+
 ## See also
 
-- `DEVLOG.md`, `ROADMAP.md`
-- Per-directory docs: `research/README.md`, `scripts/README.md`, `src/README.md`, `test/README.md`, `analysis/README.md`
+- **[RULES.md](RULES.md)** — full rules for the card variant
+- Per-directory docs: [`scripts/README.md`](scripts/README.md), [`src/README.md`](src/README.md), [`analysis/README.md`](analysis/README.md), [`test/README.md`](test/README.md), [`research/README.md`](research/README.md)

--- a/RULES.md
+++ b/RULES.md
@@ -1,0 +1,128 @@
+# Big 2 (Shanghainese Variant) — Rules
+
+A 2-player card game where you race to empty your hand by playing combinations of increasing rank. This is a stripped-down variant of the classic Chinese card game Big 2, adapted for two players.
+
+---
+
+## The Deck
+
+Start with a standard 52-card deck and **remove three of the four 2s and one of the four aces**, leaving you with:
+
+- One 2
+- Three aces
+- Four of every other rank (3 through K)
+
+**Suits are ignored entirely.** Only the rank of a card matters.
+
+---
+
+## Setup
+
+Shuffle the 48-card deck and deal it face-down into three equal piles of 16 cards. Each player takes one pile; the third pile is set aside **unseen and unused**. (This third pile means you can never be completely certain what your opponent holds.)
+
+---
+
+## Who Goes First
+
+The player holding the **3 of Spades** goes first. If that card ended up in the unused pile, check for the **4 of Spades**, then **5 of Spades**, and so on up through the spades. In the extremely unlikely event that all spades are in the unused pile, use 3♥, 4♥, 5♥, etc. instead.
+
+The player who goes first has the **initiative** for the opening trick.
+
+---
+
+## How a Trick Works
+
+The player with initiative opens by playing any valid combination face-up. Their opponent must then respond with a **combination of the same type and length, but of strictly higher rank** — or pass. Play continues back and forth until one player passes. The player who played last wins the trick and gains the initiative to open the next one.
+
+A few things to note:
+
+- You **must pass** if you have no valid higher play.
+- You **may also pass voluntarily** even if you could play.
+- There's no penalty for passing — you simply give up the initiative.
+
+---
+
+## Valid Combinations
+
+### Single
+
+Any one card. Rank order from lowest to highest: **3, 4, 5, 6, 7, 8, 9, 10, J, Q, K, A, 2**. The 2 is the single most powerful card in the deck.
+
+### Double
+
+A pair of cards with the same rank. Doubles are compared by rank, same order as singles. There is only one 2 in the deck, so **there are no double 2s**.
+
+### Triple
+
+Three cards of the same rank. Compared by rank. There are no triple aces (a triple ace is a **bomb** instead — see below) and no triple 2.
+
+### Full House
+
+A triple of one rank combined with a double of another rank — i.e. a standard poker full house. Full houses are **always compared by the rank of the triple**, regardless of the pair.
+
+### Straight
+
+Five or more cards of consecutive rank. Examples: `3-4-5-6-7`, `9-10-J-Q-K-A`.
+
+**Wrap-around rules:**
+
+- An ace may follow a king: `...-Q-K-A` is valid.
+- A 2 may follow an ace: `...-K-A-2` is valid.
+- A 2 may *also* come before a 3: `2-3-4-5-6` is valid, with the 2 acting as the lowest card.
+- An ace cannot serve as the lowest card — `A-2-3-4-5` is **invalid**.
+
+A 13-card straight covering all ranks is also possible; since only one such straight can exist, rank is irrelevant.
+
+Both players' straights in the same trick must be **exactly the same length**. Straights are compared by their highest card, using the standard rank order. Note: when a 2 is used as the low card in `2-3-4-5-6`, the straight's top card is 6 — whereas `J-Q-K-A-2` has 2 as its top card (the highest possible), making it stronger than a straight ending in an ace.
+
+### Sisters (Consecutive Pairs)
+
+Two or more consecutive pairs. Example: `7-7-8-8` or `10-10-J-J-Q-Q`. Aces may follow kings. The single 2 cannot be used. Both sisters in the same trick must be **exactly the same length**, compared by the highest pair's rank.
+
+### Triple Straight (Consecutive Triples)
+
+Two or more consecutive triples, following the same rules as Sisters but with triples. Aces cannot be used — a triple of aces is always a bomb, not part of a consecutive triple. There is no triple 2.
+
+---
+
+## Bombs 💣
+
+A bomb is a special combination: **all four cards of the same rank** (e.g. four 7s), with the option to attach any single extra card called the **auxiliary card** (e.g. four 7s + a Q). The auxiliary card doesn't affect the bomb's rank. Since there are only three aces in the deck, a triple ace is treated as the **ace bomb** — the strongest bomb in the game.
+
+Bombs are compared by the rank of the four-of-a-kind (or triple, for the ace bomb), using standard rank order. The ace bomb outranks all other bombs.
+
+**The key rule:** A bomb is a **burn** — it can be played at any time during a trick, regardless of what combination is currently on the table. It overrides whatever came before. After a bomb, the trick continues normally: the opponent can respond with a larger bomb, or pass.
+
+---
+
+## Winning
+
+The first player to play their last card wins the game. There's no special rule for the final play — you can end on any valid combination.
+
+---
+
+## Series Play
+
+Big 2 is traditionally played as a **series of games**, with points accumulating until one player wins the series.
+
+### Scoring
+
+After each game, the winner scores points equal to the **number of cards remaining in the loser's hand**, with the following exceptions for large counts — the card count is replaced by a flat bonus instead:
+
+| Cards remaining | Points scored |
+|-----------------|---------------|
+| 16 (didn't play a single card) | 50 |
+| 15 | 40 |
+| 14 | 30 |
+| 13 | 20 |
+| 12 or fewer | equal to card count |
+
+For example: if your opponent has 14 cards left, you score 30 points (not 14).
+
+### Initiative Between Games
+
+The winner of each game has the initiative to open the next game.
+
+### Winning the Series
+
+The first player to reach **50 points total** wins the series.

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -1,8 +1,10 @@
 # Analysis
 
-Python scripts for exploring Parquet exports from `bin/generate_data`. Run from the repo root (or pass explicit paths), unless noted.
+Python scripts for exploring **Parquet** exports from `bin/generate_data`, plus helpers that summarize **eval** logs. Run from the repo root (or pass explicit paths), unless noted.
 
-**Typical inputs:** `<prefix>_game.parquet` and `<prefix>_turn.parquet` produced by `scripts/generate_data.py` / `bin/generate_data`.
+**Typical Parquet inputs:** `<prefix>_game.parquet` and `<prefix>_turn.parquet` produced by `scripts/generate_data.py` / `bin/generate_data`.
+
+**Eval logs:** `scripts/analyze_eval_match.py` parses `bin/eval_match` output (or a file saved by `scripts/run_eval_match.py`, e.g. `analysis/eval_match_last.log`) and prints wins, Wilson CI, and verdict lines. See [`scripts/README.md`](../scripts/README.md).
 
 **Dependencies:** `pandas`, `numpy`, `matplotlib`, `seaborn`; `random_forest_tester.py` also needs `scikit-learn` and `joblib`.
 

--- a/research/README.md
+++ b/research/README.md
@@ -37,7 +37,7 @@ make generate_data    # produces bin/generate_data
 python3 research/game_feature_stats.py --games 10000 --player random
 ```
 
-**Inputs:** CLI flags (`--games`, `--player`, `--threads`, `--seed`, `--game-features`, etc.; see `--help`).
+**Inputs:** CLI flags (`--games`, `--player`, `--threads`, `--seed`, `--game-features`, etc.; see `--help`). `--player` uses the same names as self-play / eval (`random`, `greedy`, …; see [`scripts/README.md`](../scripts/README.md)).
 
 **Outputs:** Printed mean / stdev / min / max (and winner counts for `outcome`) from a temporary `_game.parquet`. The C++ `bin/generate_data` process also prints aggregate stats on stdout.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,53 +1,123 @@
 # Scripts
 
-Drivers and tooling that live outside the main `src/` library. Paths below are relative to the **repository root**.
+Drivers and tooling outside `src/`. Paths are relative to the **repository root**.
+
+## Policy names (`player_factory_registry.h`)
+
+These strings work anywhere the code calls `make_player_factory` (e.g. `bin/eval_match`, `bin/generate_data` for `--player`):
+
+| Name | Meaning |
+|------|---------|
+| `random` | Uniform random legal move |
+| `greedy` | Greedy heuristic (lexicographic score after each candidate move) |
+| `greedy_random` | Usually greedy; with probability `param`, play a random legal move |
+| `greedy_random_pass` | Usually greedy; with probability `param`, pass when legal |
+| `greedy_no_bomb` | Usually greedy; when greedy would play a bomb, only do so with probability `param` |
+
+Parameterized variants take `--p0-param` / `--p1-param` (or `param` in JSON configs for `eval_match` / round robin). **`bin/generate_data` fixes `param` at 0** for self-play; use `eval_match` or round robin for parameter sweeps.
+
+---
 
 ## `generate_data.py`
 
-Python wrapper around `bin/generate_data`: compiles (optional), loads JSON, runs the Parquet self-play pipeline.
+Python wrapper around `bin/generate_data`: optional compile, JSON config, Parquet self-play.
 
 **Prerequisites:** C++17, OpenMP, Apache Arrow / Parquet (`libarrow-dev`, `libparquet-dev` on Debian/Ubuntu).
 
-**Build the binary (once):**
-
 ```bash
 make generate_data
+python3 scripts/generate_data.py scripts/configs/greedy.json
+python3 scripts/generate_data.py scripts/configs/greedy.json --compile
 ```
 
-**Run:**
+**Config:** `player`, `num_games`, and (for Parquet) `output_path` plus `game_features` / `turn_features`. Optional: `threads`, `seed`, `samples_md_path`. See `scripts/configs/greedy.json`, `test.json`.
+
+**Output:** `<output_path>_game.parquet` and `<output_path>_turn.parquet`.
+
+---
+
+## `run.sh` (self-play + Parquet analysis)
+
+Runs `generate_data.py` then `analysis/analysis.py` on the produced Parquet files.
 
 ```bash
-python3 scripts/generate_data.py scripts/configs/greedy.json
-python3 scripts/generate_data.py scripts/configs/greedy.json --compile   # build then run
+./scripts/run.sh                    # default: scripts/configs/greedy.json
+./scripts/run.sh scripts/configs/test.json
 ```
 
-**Input:** A JSON config with at least `player`, `num_games`, and `output_path`. Optional keys include `game_features`, `turn_features`, `threads`, `seed` (see `scripts/configs/greedy.json` and `test.json`).
+Set `samples_md_path` in the config if you want anomaly game histories from `generate_data`.
 
-**Output:** Two Parquet files next to the configured base path:
+---
 
-- `<output_path>_game.parquet` — one row per game (game-level features)
-- `<output_path>_turn.parquet` — one row per turn (turn-level features)
+## `run_eval_match.sh` / `run_eval_match.py`
 
-Paths are resolved from the repo root unless `output_path` is absolute.
+Head-to-head evaluation via `bin/eval_match`: **paired deals** (both seats per deal), **Wilson 95% CI**, full log + optional `scripts/analyze_eval_match.py` summary.
+
+**Prerequisites:** `make eval_match` (no Arrow).
+
+```bash
+./scripts/run_eval_match.sh
+./scripts/run_eval_match.sh scripts/configs/eval_match.json
+python3 scripts/run_eval_match.py scripts/configs/eval_match.json --compile
+```
+
+**Config** (`scripts/configs/eval_match.json`): `p0`, `p1`, `deals`; optional `p0_param`, `p1_param`, `seed`, `threads`, `output_log` (default `analysis/eval_match_last.log`).
+
+**Analyze an existing log:**
+
+```bash
+python3 scripts/analyze_eval_match.py --file analysis/eval_match_last.log
+./bin/eval_match ... 2>&1 | python3 scripts/analyze_eval_match.py
+```
+
+---
+
+## `analyze_eval_match.py`
+
+Parses `eval_match` stdout and prints a short markdown-style summary (wins, CI, result line). Used by `run_eval_match.py`; can be run standalone on a saved log.
+
+---
+
+## `round_robin_eval.py` / `run_round_robin.sh`
+
+**Round robin:** for each unordered pair of players, runs `bin/eval_match` once (same fairness as a single head-to-head). Prints a **win-rate matrix** and **aggregate standings**.
+
+**Prerequisites:** `make eval_match`
+
+```bash
+./scripts/run_round_robin.sh
+./scripts/run_round_robin.sh scripts/configs/round_robin_example.json
+python3 scripts/round_robin_eval.py scripts/configs/round_robin_example.json --compile
+python3 scripts/round_robin_eval.py scripts/configs/round_robin_example.json --quiet --deals 500
+```
+
+**Config** (`scripts/configs/round_robin_example.json`):
+
+- `players`: list of strings (`"greedy"`, `"random"`) or objects `{ "type": "...", "param": 0.2, "label": "..." }`.
+- The example includes **`random`** and **`greedy`**, plus each greedy variant at **five** `param` values **0.1–0.5** (17 players → **136** pairwise matchups—use `--deals` to shorten test runs).
+- `deals_per_matchup` or `k`: deals per pair (total games per pair = `2 × deals`). Override with `--deals N`.
+
+---
 
 ## `tablebase_opp1_gen.cpp`
 
-Source for the opponent-has-one-card tablebase **precompute** tool (not built by `generate_data`).
-
-**Build:**
+Source for the opponent-has-one-card tablebase **precompute** (not built by `generate_data`).
 
 ```bash
 make tablebase_opp1_gen
-```
-
-**Run:**
-
-```bash
 ./bin/tablebase_opp1_gen [out.bin] [samples.txt]
 ```
 
-**Output:** A binary tablebase file (loaded at runtime via `src/core/tablebase_opp1.*`) and an optional text sample file for debugging. See the root `README.md` tablebase section.
+See root `README.md` and `src/core/tablebase_opp1.*`.
+
+---
 
 ## `configs/`
 
-Example JSON configs for `generate_data.py`. Copy and edit `output_path`, `num_games`, feature lists, and `threads` for your machine.
+| File | Used by |
+|------|---------|
+| `greedy.json`, `test.json` | `generate_data.py` |
+| `eval_match.json` | `run_eval_match.py` |
+| `round_robin_example.json` | `round_robin_eval.py` |
+
+Copy and edit paths, `num_games` / `deals`, feature lists, and `threads` for your machine.

--- a/scripts/analyze_eval_match.py
+++ b/scripts/analyze_eval_match.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Parse stdout/stderr from bin/eval_match and print a short summary.
+
+Designed to be piped after a match run, or given a log file:
+
+  ./bin/eval_match ... 2>&1 | python3 scripts/analyze_eval_match.py
+  python3 scripts/analyze_eval_match.py --file analysis/eval_match_last.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def analyze_text(text: str) -> str:
+    lines = []
+    title = None
+    m = re.search(r"=== Eval Match:\s*(.+?)\s*===", text)
+    if m:
+        title = m.group(1).strip()
+        lines.append(f"**Match:** {title}")
+
+    # Name may contain ")" (e.g. greedy_random(0.1)); match from P0 through " wins:".
+    m = re.search(
+        r"P0\s+(.+?)\s+wins:\s*(\d+)\s*/\s*(\d+)\s*\(([\d.]+)%\)",
+        text,
+    )
+    if m:
+        name, wins, total, pct = m.group(1).strip(), m.group(2), m.group(3), m.group(4)
+        lines.append(f"**P0 wins:** {wins} / {total} ({pct}%)  (`{name}`)")
+
+    m = re.search(
+        r"95% Wilson CI:\s*\[([\d.]+)%\s*,\s*([\d.]+)%\]",
+        text,
+    )
+    if m:
+        lines.append(f"**95% Wilson CI:** [{m.group(1)}%, {m.group(2)}%]")
+
+    m = re.search(r"Result:\s*(.+?)(?:\n|$)", text)
+    if m:
+        lines.append(f"**Result:** {m.group(1).strip()}")
+
+    m = re.search(r"Elapsed:\s*(.+?)(?:\n|$)", text)
+    if m:
+        lines.append(f"**Elapsed:** {m.group(1).strip()}")
+
+    if not lines:
+        return "(Could not parse eval_match output — paste full log.)\n"
+
+    out = "\n".join(lines) + "\n"
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Summarize eval_match output")
+    parser.add_argument(
+        "--file",
+        "-f",
+        type=Path,
+        help="Read from file instead of stdin",
+    )
+    args = parser.parse_args()
+
+    if args.file:
+        text = args.file.read_text(encoding="utf-8", errors="replace")
+    else:
+        text = sys.stdin.read()
+
+    print("--- eval_match analysis ---")
+    sys.stdout.write(analyze_text(text))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/configs/eval_match.json
+++ b/scripts/configs/eval_match.json
@@ -1,0 +1,10 @@
+{
+  "p0": "greedy",
+  "p0_param": 0.0,
+  "p1": "random",
+  "p1_param": 0.0,
+  "deals": 10000,
+  "seed": 42,
+  "threads": 8,
+  "output_log": "analysis/eval_match_last.log"
+}

--- a/scripts/configs/round_robin_example.json
+++ b/scripts/configs/round_robin_example.json
@@ -1,0 +1,24 @@
+{
+  "deals_per_matchup": 5000,
+  "seed": 42,
+  "threads": 8,
+  "players": [
+    "random",
+    "greedy",
+    { "type": "greedy_random", "param": 0.1, "label": "greedy_random(0.1)" },
+    { "type": "greedy_random", "param": 0.2, "label": "greedy_random(0.2)" },
+    { "type": "greedy_random", "param": 0.3, "label": "greedy_random(0.3)" },
+    { "type": "greedy_random", "param": 0.4, "label": "greedy_random(0.4)" },
+    { "type": "greedy_random", "param": 0.5, "label": "greedy_random(0.5)" },
+    { "type": "greedy_random_pass", "param": 0.1, "label": "greedy_random_pass(0.1)" },
+    { "type": "greedy_random_pass", "param": 0.2, "label": "greedy_random_pass(0.2)" },
+    { "type": "greedy_random_pass", "param": 0.3, "label": "greedy_random_pass(0.3)" },
+    { "type": "greedy_random_pass", "param": 0.4, "label": "greedy_random_pass(0.4)" },
+    { "type": "greedy_random_pass", "param": 0.5, "label": "greedy_random_pass(0.5)" },
+    { "type": "greedy_no_bomb", "param": 0.1, "label": "greedy_no_bomb(0.1)" },
+    { "type": "greedy_no_bomb", "param": 0.2, "label": "greedy_no_bomb(0.2)" },
+    { "type": "greedy_no_bomb", "param": 0.3, "label": "greedy_no_bomb(0.3)" },
+    { "type": "greedy_no_bomb", "param": 0.4, "label": "greedy_no_bomb(0.4)" },
+    { "type": "greedy_no_bomb", "param": 0.5, "label": "greedy_no_bomb(0.5)" }
+  ]
+}

--- a/scripts/round_robin_eval.py
+++ b/scripts/round_robin_eval.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+Round-robin tournament: every pair of players runs bin/eval_match once with the
+same paired-deal protocol as a single matchup (K deals → 2*K total games).
+
+Config JSON:
+  players            — required, list of player specs (see below)
+  deals_per_matchup  — or "k": number of deals per pairwise matchup (required)
+  seed               — optional base seed (default: random)
+  threads            — optional, passed to each eval_match
+  compile            — optional: set true to run make eval_match first (or use --compile)
+
+Each player spec is either a string (player type name) or an object:
+  { "type": "greedy_no_bomb", "param": 0.3, "label": "nb0.3" }
+  type   — required (random, greedy, greedy_random, …)
+  param  — optional float, default 0
+  label  — optional short name for tables (default: type, or type(param))
+
+Example:
+  python scripts/round_robin_eval.py scripts/configs/round_robin_example.json
+  python scripts/round_robin_eval.py scripts/configs/round_robin_example.json --compile
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Labels may contain parentheses (e.g. greedy_random(0.1)); do not use [^)]+ for the name.
+WINS_RE = re.compile(
+    r"P0\s+.+\s+wins:\s*(\d+)\s*/\s*(\d+)\s*\(([\d.]+)%\)",
+    re.MULTILINE,
+)
+
+
+def compile_binary(verbose: bool = True) -> None:
+    if verbose:
+        print("Compiling eval_match binary...", flush=True)
+    result = subprocess.run(
+        ["make", "eval_match"],
+        cwd=str(REPO_ROOT),
+        capture_output=not verbose,
+        text=True,
+    )
+    if result.returncode != 0:
+        print("Compilation failed!", file=sys.stderr)
+        if not verbose:
+            print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+    if verbose:
+        print("Compilation successful.\n", flush=True)
+
+
+def load_config(path: str | Path) -> dict:
+    p = Path(path)
+    if not p.is_absolute():
+        p = (REPO_ROOT / p).resolve()
+    if not p.exists():
+        print(f"Config not found: {p}", file=sys.stderr)
+        sys.exit(1)
+    with open(p, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def normalize_players(raw: list) -> list[dict]:
+    out: list[dict] = []
+    for i, p in enumerate(raw):
+        if isinstance(p, str):
+            out.append({"type": p, "param": 0.0, "label": p, "_idx": i})
+            continue
+        if not isinstance(p, dict) or "type" not in p:
+            print(f"Invalid player entry at index {i}: {p!r}", file=sys.stderr)
+            sys.exit(1)
+        t = str(p["type"])
+        param = float(p.get("param", 0.0))
+        label = p.get("label")
+        if not label:
+            label = t if param == 0.0 else f"{t}({param:g})"
+        out.append({"type": t, "param": param, "label": str(label), "_idx": i})
+    return out
+
+
+def deals_from_config(cfg: dict) -> int:
+    if "deals_per_matchup" in cfg:
+        return int(cfg["deals_per_matchup"])
+    if "k" in cfg:
+        return int(cfg["k"])
+    print(
+        'Config must include "deals_per_matchup" or "k" (deals per pairwise matchup).',
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def parse_eval_wins(text: str) -> tuple[int, int] | None:
+    m = WINS_RE.search(text)
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2))
+
+
+def build_eval_cmd(
+    p0: dict,
+    p1: dict,
+    deals: int,
+    seed: int,
+    threads: int | None,
+) -> list[str]:
+    cmd = [
+        str(REPO_ROOT / "bin" / "eval_match"),
+        "--p0",
+        p0["type"],
+        "--p1",
+        p1["type"],
+        "--deals",
+        str(deals),
+        "--seed",
+        str(seed),
+    ]
+    cmd.extend(["--p0-param", str(p0["param"])])
+    cmd.extend(["--p1-param", str(p1["param"])])
+    if threads is not None:
+        cmd.extend(["--threads", str(threads)])
+    return cmd
+
+
+def run_one_matchup(cmd: list[str], quiet: bool) -> tuple[int, str]:
+    result = subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    text = result.stdout
+    if not quiet:
+        print(text, end="", flush=True)
+    return result.returncode, text
+
+
+def format_matrix(
+    labels: list[str],
+    win_rate: list[list[float | None]],
+) -> str:
+    n = len(labels)
+    w = max(len("vs") + 1, max(len(x) for x in labels) + 1, 8)
+    lines = []
+    header = " " * w + "".join(f"{labels[j][: w - 1]:>{w}}" for j in range(n))
+    lines.append(header)
+    for i in range(n):
+        row = f"{labels[i][: w - 1]:<{w}}"
+        for j in range(n):
+            if i == j:
+                cell = "—"
+            else:
+                r = win_rate[i][j]
+                cell = f"{100.0 * r:.1f}%" if r is not None else "?"
+            row += f"{cell:>{w}}"
+        lines.append(row)
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Round-robin eval_match tournament from JSON config",
+    )
+    parser.add_argument("config", help="Path to JSON configuration")
+    parser.add_argument(
+        "-c",
+        "--compile",
+        action="store_true",
+        help="Compile eval_match before running",
+    )
+    parser.add_argument(
+        "--no-compile",
+        action="store_true",
+        help="Skip auto-compile if binary missing",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Only print one line per matchup + final summary (hide eval_match spam)",
+    )
+    parser.add_argument(
+        "--deals",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Override deals_per_matchup / k from the config",
+    )
+    args = parser.parse_args()
+
+    binary = REPO_ROOT / "bin" / "eval_match"
+    if args.compile or (not binary.exists() and not args.no_compile):
+        compile_binary()
+    elif not binary.exists():
+        print(f"Binary '{binary}' not found. Use --compile.", file=sys.stderr)
+        sys.exit(1)
+
+    cfg = load_config(args.config)
+    if "players" not in cfg or not isinstance(cfg["players"], list):
+        print('Config must contain a non-empty "players" list.', file=sys.stderr)
+        sys.exit(1)
+    players = normalize_players(cfg["players"])
+    n = len(players)
+    if n < 2:
+        print("Need at least 2 players for a round robin.", file=sys.stderr)
+        sys.exit(1)
+
+    deals = args.deals if args.deals is not None else deals_from_config(cfg)
+    if deals <= 0:
+        print("deals_per_matchup / k / --deals must be positive.", file=sys.stderr)
+        sys.exit(1)
+    base_seed = int(cfg["seed"]) if "seed" in cfg else None
+    if base_seed is None:
+        import random
+
+        base_seed = random.randint(0, 2**31 - 1)
+    threads = cfg.get("threads")
+    if threads is not None:
+        threads = int(threads)
+
+    labels = [p["label"] for p in players]
+    print(
+        f"Round robin: {n} players, {deals} deals per matchup "
+        f"({2 * deals} games per pair), base_seed={base_seed}\n",
+        flush=True,
+    )
+
+    # wins_first[(i,j)] = (wins for player i, total games), i < j
+    wins_first: dict[tuple[int, int], tuple[int, int]] = {}
+
+    pair_index = 0
+    total_pairs = n * (n - 1) // 2
+    t0 = time.perf_counter()
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            pair_index += 1
+            # Distinct seed per pair so matchups are independent but reproducible.
+            seed = (base_seed + i * 100003 + j * 1000003) & 0xFFFFFFFF
+            cmd = build_eval_cmd(players[i], players[j], deals, seed, threads)
+            print(
+                f"[{pair_index}/{total_pairs}] {labels[i]}  vs  {labels[j]}  "
+                f"(seed={seed})",
+                flush=True,
+            )
+            code, text = run_one_matchup(cmd, quiet=args.quiet)
+            if code != 0:
+                print(f"eval_match failed with code {code}", file=sys.stderr)
+                sys.exit(code)
+            parsed = parse_eval_wins(text)
+            if parsed is None:
+                print("Could not parse wins from eval_match output.", file=sys.stderr)
+                sys.exit(1)
+            w, tot = parsed
+            wins_first[(i, j)] = (w, tot)
+            pct = 100.0 * w / tot if tot else 0.0
+            print(
+                f"    → P0 ({labels[i]}) wins {w}/{tot} ({pct:.2f}%)\n",
+                flush=True,
+            )
+
+    elapsed = time.perf_counter() - t0
+
+    # Win rate matrix: rate[i][j] = fraction of games won by i vs j
+    rate: list[list[float | None]] = [[None] * n for _ in range(n)]
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                continue
+            if i < j:
+                w, t = wins_first[(i, j)]
+                rate[i][j] = w / t if t else 0.0
+                rate[j][i] = (t - w) / t if t else 0.0
+            # j < i filled when processing (j, i)
+
+    # Total wins across all games for each player
+    total_wins = [0] * n
+    total_games = [0] * n
+    for i in range(n):
+        for j in range(n):
+            if i >= j:
+                continue
+            w, t = wins_first[(i, j)]
+            total_wins[i] += w
+            total_wins[j] += t - w
+            total_games[i] += t
+            total_games[j] += t
+
+    print("=" * 72)
+    print("Win rate matrix (row vs column: row win % in that matchup)")
+    print("=" * 72)
+    print(format_matrix(labels, rate))
+    print()
+    print("Standings (by total wins, then win rate)")
+    print("-" * 72)
+    rows = []
+    for i in range(n):
+        tg = total_games[i]
+        wr = total_wins[i] / tg if tg else 0.0
+        rows.append((-total_wins[i], -wr, labels[i], total_wins[i], tg, wr))
+    rows.sort()
+    for rank, (_, _, lab, tw, tg, wr) in enumerate(rows, start=1):
+        print(
+            f"  {rank}. {lab:24}  wins {tw:6} / {tg:6}  ({100.0 * wr:.2f}%)",
+        )
+    print("-" * 72)
+    print(f"Elapsed: {elapsed:.1f}s  ({total_pairs} matchups)\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_eval_match.py
+++ b/scripts/run_eval_match.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Run head-to-head evaluation (bin/eval_match), save a log, print raw output,
+then run analyze_eval_match on the same text.
+
+Usage:
+  python scripts/run_eval_match.py scripts/configs/eval_match.json
+  python scripts/run_eval_match.py scripts/configs/eval_match.json --compile
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def compile_binary(verbose: bool = True) -> None:
+    if verbose:
+        print("Compiling eval_match binary...")
+    result = subprocess.run(
+        ["make", "eval_match"],
+        cwd=str(REPO_ROOT),
+        capture_output=not verbose,
+        text=True,
+    )
+    if result.returncode != 0:
+        print("Compilation failed!", file=sys.stderr)
+        if not verbose:
+            print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+    if verbose:
+        print("Compilation successful.\n")
+
+
+def load_config(config_path: str) -> dict:
+    config_file = Path(config_path)
+    if not config_file.is_absolute():
+        config_file = (REPO_ROOT / config_path).resolve()
+    if not config_file.exists():
+        print(f"Config file not found: {config_file}", file=sys.stderr)
+        sys.exit(1)
+    with open(config_file, encoding="utf-8") as f:
+        config = json.load(f)
+    required = ["p0", "p1", "deals"]
+    missing = [k for k in required if k not in config]
+    if missing:
+        print(f"Config missing required fields: {missing}", file=sys.stderr)
+        sys.exit(1)
+    return config
+
+
+def build_cmd(config: dict) -> list[str]:
+    binary = REPO_ROOT / "bin" / "eval_match"
+    cmd = [
+        str(binary),
+        "--p0",
+        config["p0"],
+        "--p1",
+        config["p1"],
+        "--deals",
+        str(config["deals"]),
+    ]
+    if config.get("p0_param") is not None:
+        cmd.extend(["--p0-param", str(config["p0_param"])])
+    if config.get("p1_param") is not None:
+        cmd.extend(["--p1-param", str(config["p1_param"])])
+    if "seed" in config:
+        cmd.extend(["--seed", str(config["seed"])])
+    if "threads" in config:
+        cmd.extend(["--threads", str(config["threads"])])
+    return cmd
+
+
+def run_eval(config: dict) -> tuple[int, str]:
+    cmd = build_cmd(config)
+    print("Running eval_match...")
+    print(f"Command: {' '.join(cmd)}\n")
+
+    result = subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    # Merged stdout+stderr for one log (progress + summary)
+    full_output = result.stdout
+    return result.returncode, full_output
+
+
+def resolve_output_log(config: dict) -> Path:
+    raw = config.get("output_log", "analysis/eval_match_last.log")
+    p = Path(raw)
+    if not p.is_absolute():
+        p = REPO_ROOT / p
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run eval_match from JSON config, log, and analyze",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Example:
+  python scripts/run_eval_match.py scripts/configs/eval_match.json
+  python scripts/run_eval_match.py scripts/configs/eval_match.json --compile
+        """,
+    )
+    parser.add_argument("config", help="Path to JSON configuration file")
+    parser.add_argument(
+        "-c",
+        "--compile",
+        action="store_true",
+        help="Compile eval_match before running",
+    )
+    parser.add_argument(
+        "--no-compile",
+        action="store_true",
+        help="Skip compilation even if binary is missing",
+    )
+    args = parser.parse_args()
+
+    binary = REPO_ROOT / "bin" / "eval_match"
+    if args.compile or (not binary.exists() and not args.no_compile):
+        compile_binary()
+    elif not binary.exists():
+        print(f"Binary '{binary}' not found!", file=sys.stderr)
+        print("  Run with --compile to build it first", file=sys.stderr)
+        sys.exit(1)
+
+    config = load_config(args.config)
+    log_path = resolve_output_log(config)
+
+    code, full_output = run_eval(config)
+
+    log_path.write_text(full_output, encoding="utf-8")
+    print(full_output, end="", flush=True)
+    print(f"\nWrote full log to: {log_path}\n", flush=True)
+
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    from analyze_eval_match import analyze_text  # noqa: E402
+
+    print("--- eval_match analysis ---", flush=True)
+    sys.stdout.write(analyze_text(full_output))
+    sys.stdout.flush()
+
+    if code != 0:
+        sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_eval_match.sh
+++ b/scripts/run_eval_match.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Run eval_match from a JSON config, save a log, print output, then analyze (like run.sh for self-play).
+# Usage:
+#   ./scripts/run_eval_match.sh [path/to/config.json]
+# Default config: scripts/configs/eval_match.json
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CONFIG_ARG="${1:-scripts/configs/eval_match.json}"
+shift || true
+
+exec python3 "$ROOT/scripts/run_eval_match.py" "$CONFIG_ARG" "$@"

--- a/scripts/run_round_robin.sh
+++ b/scripts/run_round_robin.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Round-robin tournament via scripts/round_robin_eval.py (calls bin/eval_match per pair).
+# Usage:
+#   ./scripts/run_round_robin.sh [path/to/config.json] [extra args to round_robin_eval.py]
+# Default config: scripts/configs/round_robin_example.json
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CONFIG_ARG="${1:-scripts/configs/round_robin_example.json}"
+shift || true
+
+exec python3 "$ROOT/scripts/round_robin_eval.py" "$CONFIG_ARG" "$@"

--- a/src/README.md
+++ b/src/README.md
@@ -21,7 +21,8 @@ Game rules and shared state:
 Abstract **`player.h`** and factories:
 
 - **`random/`** — uniform random legal move.
-- **`greedy/`** — heuristic policy (used in self-play and tests).
+- **`greedy/`** — greedy heuristic (`greedy_player.h`): among non-pass moves, pick the post-move state with best lexicographic score (bombs, fewer cards left, then rank counts 2 down to 4; 3s are implied by the rest). Variants: **`greedy_random_player`**, **`greedy_random_pass_player`**, **`greedy_no_bomb_player`** (each with a float parameter and factory).
+- **`player_factory_registry.h`** — `make_player_factory(name, param, seed)` for `bin/generate_data`, `bin/eval_match`, and Python drivers.
 
 Policies can use the tablebase when the engine provides it.
 
@@ -38,5 +39,6 @@ Header-only **feature extractors** registered by name for datagen:
 Binaries are linked from the repo `Makefile`, not as a separate library:
 
 - **`generate_data.cpp`** — CLI entry for threaded self-play, stats, optional Parquet + sample Markdown (`bin/generate_data`).
+- **`eval_match.cpp`** — CLI entry for pairwise evaluation with paired deals and Wilson CI (`bin/eval_match`, no Arrow).
 - **`samples_md.*`** — writes anomaly game histories for `--samples-md`.
 - **`parquet_export.*`, `feature_registry.h`** — Arrow/Parquet schema and feature column wiring.

--- a/src/datagen/eval_match.cpp
+++ b/src/datagen/eval_match.cpp
@@ -1,0 +1,237 @@
+#include "game_simulator.h"
+#include "player_factory_registry.h"
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+// ============================================================================
+// Wilson score 95% confidence interval for a proportion
+// ============================================================================
+
+struct WilsonCI {
+  double lo, hi;
+};
+
+static WilsonCI wilson_ci(double p_hat, long n, double z = 1.96) {
+  double z2 = z * z;
+  double n_inv = 1.0 / static_cast<double>(n);
+  double center = (p_hat + z2 * n_inv / 2.0) / (1.0 + z2 * n_inv);
+  double half = z * std::sqrt(p_hat * (1.0 - p_hat) * n_inv + z2 * n_inv * n_inv / 4.0) /
+                (1.0 + z2 * n_inv);
+  return {center - half, center + half};
+}
+
+// ============================================================================
+// Paired deal simulation
+//
+// For each deal index i, we seed an rng with (base_seed + i). We run two
+// games from that seed: one where A=P0, B=P1, and one where A=P1, B=P0.
+// Because both rngs start from the same seed, both games see the same card
+// distribution, which cancels out luck from the deal.
+// ============================================================================
+
+static int run_paired_deal(unsigned int deal_seed,
+                            PlayerFactory &factory_a, PlayerFactory &factory_b) {
+  int a_wins = 0;
+
+  for (int swap = 0; swap < 2; ++swap) {
+    std::mt19937 rng(deal_seed);
+    auto p0 = (swap == 0) ? factory_a.create_player() : factory_b.create_player();
+    auto p1 = (swap == 0) ? factory_b.create_player() : factory_a.create_player();
+    GameSimulator sim(std::move(p0), std::move(p1), rng);
+    GameRecord rec = sim.run();
+    int winner = rec.game().get_winner();
+    // winner==0 means P0 won; A is P0 when swap==0, P1 when swap==1
+    if ((swap == 0 && winner == 0) || (swap == 1 && winner == 1))
+      ++a_wins;
+  }
+  return a_wins;
+}
+
+// ============================================================================
+// CLI helpers
+// ============================================================================
+
+static void print_usage(const char *prog) {
+  std::cout
+      << "Usage: " << prog << " [options]\n"
+      << "Options:\n"
+      << "  --p0 <name>          Player A type (required)\n"
+      << "  --p0-param <f>       Parameter for player A (default: 0.0)\n"
+      << "  --p1 <name>          Player B type (required)\n"
+      << "  --p1-param <f>       Parameter for player B (default: 0.0)\n"
+      << "  --deals <N>          Number of unique deals (total games = 2*N) (required)\n"
+      << "  --seed <S>           Base RNG seed (default: random)\n"
+      << "  --threads <T>        Worker threads (default: hardware - 2)\n"
+      << "\nAvailable players: random, greedy, greedy_random, greedy_random_pass, greedy_no_bomb\n"
+      << "\nExample:\n"
+      << "  " << prog
+      << " --p0 greedy_no_bomb --p0-param 0.3 --p1 greedy --deals 50000\n";
+}
+
+static std::string player_label(const std::string &name, double param) {
+  if (name == "greedy" || name == "random")
+    return name;
+  char buf[64];
+  std::snprintf(buf, sizeof(buf), "%s(%.2g)", name.c_str(), param);
+  return buf;
+}
+
+static std::string format_elapsed(long long ms) {
+  if (ms < 1000) {
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%lld ms", ms);
+    return buf;
+  }
+  char buf[64];
+  double s = ms / 1000.0;
+  if (s < 60)
+    std::snprintf(buf, sizeof(buf), "%.1f s", s);
+  else
+    std::snprintf(buf, sizeof(buf), "%dm %ds", (int)(s / 60), (int)s % 60);
+  return buf;
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char **argv) {
+  std::string p0_name, p1_name;
+  double p0_param = 0.0, p1_param = 0.0;
+  int num_deals = 0;
+  unsigned int seed = std::random_device{}();
+  int num_threads = std::max(1u, std::thread::hardware_concurrency() - 2);
+
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "--help" || arg == "-h") {
+      print_usage(argv[0]);
+      return 0;
+    } else if (arg == "--p0" && i + 1 < argc)
+      p0_name = argv[++i];
+    else if (arg == "--p0-param" && i + 1 < argc)
+      p0_param = std::stod(argv[++i]);
+    else if (arg == "--p1" && i + 1 < argc)
+      p1_name = argv[++i];
+    else if (arg == "--p1-param" && i + 1 < argc)
+      p1_param = std::stod(argv[++i]);
+    else if (arg == "--deals" && i + 1 < argc)
+      num_deals = std::stoi(argv[++i]);
+    else if (arg == "--seed" && i + 1 < argc)
+      seed = static_cast<unsigned int>(std::stoul(argv[++i]));
+    else if (arg == "--threads" && i + 1 < argc)
+      num_threads = std::stoi(argv[++i]);
+    else {
+      std::cerr << "Unknown argument: " << arg << "\n";
+      print_usage(argv[0]);
+      return 1;
+    }
+  }
+
+  if (p0_name.empty() || p1_name.empty() || num_deals <= 0) {
+    std::cerr << "Error: --p0, --p1, and --deals are required\n\n";
+    print_usage(argv[0]);
+    return 1;
+  }
+
+  std::string label0 = player_label(p0_name, p0_param);
+  std::string label1 = player_label(p1_name, p1_param);
+  long total_games = 2L * num_deals;
+
+  std::cout << "\n=== Eval Match: " << label0 << " vs " << label1 << " ===\n"
+            << "Deals:   " << num_deals << "  |  Total games: " << total_games << "\n"
+            << "Seed:    " << seed << "\n"
+            << "Threads: " << num_threads << "\n\n";
+
+  // Each thread gets factories seeded differently to avoid seed collisions
+  // across threads (factories increment seeds per player created).
+  // We give thread t an offset of t * 1000003 from the base seed.
+  std::atomic<int> next_deal{0};
+  std::atomic<long> a_wins_total{0};
+
+  auto t_start = std::chrono::high_resolution_clock::now();
+
+  std::vector<std::thread> workers;
+  workers.reserve(num_threads);
+  for (int t = 0; t < num_threads; ++t) {
+    workers.emplace_back([&, t]() {
+      // Per-thread factories with distinct seeds so player RNGs don't overlap.
+      unsigned int thread_seed = seed + static_cast<unsigned int>(t) * 1000003u;
+      auto fa = make_player_factory(p0_name, p0_param, thread_seed);
+      auto fb = make_player_factory(p1_name, p1_param, thread_seed + 500009u);
+      if (!fa || !fb) return;
+
+      int deal_idx;
+      long local_wins = 0;
+      while ((deal_idx = next_deal.fetch_add(1)) < num_deals) {
+        // Deal seed is deterministic from the global seed + deal index so
+        // that every thread arrives at the same card distribution for deal i.
+        unsigned int deal_seed = seed + static_cast<unsigned int>(deal_idx);
+        local_wins += run_paired_deal(deal_seed, *fa, *fb);
+      }
+      a_wins_total.fetch_add(local_wins);
+    });
+  }
+
+  // Progress monitor
+  std::atomic<bool> progress_done{false};
+  auto t_prog = std::chrono::steady_clock::now();
+  std::thread progress_thread([&]() {
+    while (!progress_done.load()) {
+      int done = next_deal.load();
+      if (done > num_deals) done = num_deals;
+      auto now = std::chrono::steady_clock::now();
+      double elapsed = std::chrono::duration<double>(now - t_prog).count();
+      double rate = elapsed > 0 ? (2.0 * done) / elapsed : 0;
+      int pct = num_deals > 0 ? static_cast<int>(100.0 * done / num_deals) : 0;
+      std::fprintf(stderr, "\rDeals: %d/%d (%d%%)  |  %.0f games/s   ",
+                   done, num_deals, pct, rate);
+      std::fflush(stderr);
+      if (done >= num_deals) break;
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+  });
+
+  for (auto &w : workers)
+    if (w.joinable()) w.join();
+
+  progress_done = true;
+  if (progress_thread.joinable()) progress_thread.join();
+  std::fprintf(stderr, "\n");
+
+  auto t_end = std::chrono::high_resolution_clock::now();
+  long long elapsed_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(t_end - t_start).count();
+
+  long a_wins = a_wins_total.load();
+  double p_hat = static_cast<double>(a_wins) / static_cast<double>(total_games);
+  WilsonCI ci = wilson_ci(p_hat, total_games);
+  double games_per_sec = elapsed_ms > 0 ? 1000.0 * total_games / elapsed_ms : 0;
+
+  std::cout << "P0 (" << label0 << ") wins: " << a_wins << " / " << total_games
+            << " (" << std::fixed;
+  std::cout.precision(2);
+  std::cout << 100.0 * p_hat << "%)\n";
+  std::cout << "95% Wilson CI: [" << 100.0 * ci.lo << "%, " << 100.0 * ci.hi << "%]\n";
+
+  if (ci.lo > 0.50)
+    std::cout << "Result: " << label0 << " is significantly better (CI excludes 50%)\n";
+  else if (ci.hi < 0.50)
+    std::cout << "Result: " << label1 << " is significantly better (CI excludes 50%)\n";
+  else
+    std::cout << "Result: no significant difference (CI includes 50%)\n";
+
+  std::cout << "Elapsed: " << format_elapsed(elapsed_ms)
+            << "  (" << static_cast<long>(games_per_sec) << " games/s)\n\n";
+
+  return 0;
+}

--- a/src/datagen/generate_data.cpp
+++ b/src/datagen/generate_data.cpp
@@ -1,9 +1,7 @@
 #include "feature_registry.h"
 #include "game_coordinator.h"
 #include "samples_md.h"
-#include "greedy/greedy_player_factory.h"
-#include "random/random_player_factory.h"
-#include "player_factory.h"
+#include "player_factory_registry.h"
 
 #include <atomic>
 #include <chrono>
@@ -30,13 +28,6 @@ static std::vector<std::string> split_csv(const std::string &s) {
   return tokens;
 }
 
-static std::shared_ptr<PlayerFactory> make_factory(const std::string &name,
-                                                     unsigned int seed) {
-  if (name == "random") return std::make_shared<RandomPlayerFactory>(seed);
-  if (name == "greedy") return std::make_shared<GreedyPlayerFactory>();
-  std::cerr << "Error: unknown player '" << name << "'\n";
-  return nullptr;
-}
 
 static std::string format_eta(double seconds) {
   if (seconds < 0 || !std::isfinite(seconds))
@@ -89,7 +80,8 @@ static void print_usage(const char *prog) {
       << "  --seed <S>                 RNG seed (default: random)\n"
       << "  --threads <T>              Threads (default: hardware - 2)\n"
       << "  --samples-md <path>        Markdown: anomaly games with hands + history\n"
-      << "\nAvailable players: random, greedy\n"
+      << "\nAvailable players: random, greedy, greedy_random, greedy_random_pass, greedy_no_bomb\n"
+      << "  (greedy_random, greedy_random_pass, greedy_no_bomb are only valid in eval_match)\n"
       << "\nExample:\n"
       << "  " << prog
       << " --player random --games 100000 --output data/random_100k"
@@ -168,7 +160,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  auto factory = make_factory(player_name, seed);
+  auto factory = make_player_factory(player_name, 0.0, seed);
   if (!factory) return 1;
 
   std::cout << "\n=== Data generation / self-play ===\n"

--- a/src/players/greedy/greedy_no_bomb_player.h
+++ b/src/players/greedy/greedy_no_bomb_player.h
@@ -1,0 +1,54 @@
+#ifndef GREEDY_NO_BOMB_PLAYER_H
+#define GREEDY_NO_BOMB_PLAYER_H
+
+#include "greedy_player.h"
+
+#include <random>
+#include <vector>
+
+// Plays greedy, but suppresses bomb plays with probability (1 - p_bomb).
+// When suppressed:
+//   1. Pass if available.
+//   2. Otherwise play the greedy-best non-bomb move.
+//   3. If no non-bomb moves exist, play the bomb anyway.
+class GreedyNoBombPlayer : public GreedyPlayer {
+public:
+  explicit GreedyNoBombPlayer(float p_bomb, unsigned int seed)
+      : p_bomb_(p_bomb), rng_(seed) {}
+
+protected:
+  Move select_move_impl() override {
+    std::vector<int> legal = game_.get_legal_moves();
+    Move chosen = greedy_best(game_, legal);
+
+    if (chosen.combination != Move::Combination::kBomb)
+      return chosen;
+
+    std::uniform_real_distribution<float> coin(0.0f, 1.0f);
+    if (coin(rng_) < p_bomb_)
+      return chosen;
+
+    // Suppress the bomb: prefer pass, then best non-bomb, then bomb as fallback.
+    for (int m : legal) {
+      if (Move(m).combination == Move::Combination::kPass)
+        return Move(kPASS);
+    }
+
+    std::vector<int> no_bomb;
+    no_bomb.reserve(legal.size());
+    for (int m : legal) {
+      if (Move(m).combination != Move::Combination::kBomb)
+        no_bomb.push_back(m);
+    }
+    if (!no_bomb.empty())
+      return greedy_best(game_, no_bomb);
+
+    return chosen;
+  }
+
+private:
+  float p_bomb_;
+  std::mt19937 rng_;
+};
+
+#endif

--- a/src/players/greedy/greedy_no_bomb_player_factory.h
+++ b/src/players/greedy/greedy_no_bomb_player_factory.h
@@ -1,0 +1,23 @@
+#ifndef GREEDY_NO_BOMB_PLAYER_FACTORY_H
+#define GREEDY_NO_BOMB_PLAYER_FACTORY_H
+
+#include "greedy_no_bomb_player.h"
+#include "player_factory.h"
+
+#include <memory>
+
+class GreedyNoBombPlayerFactory : public PlayerFactory {
+public:
+  explicit GreedyNoBombPlayerFactory(float p_bomb, unsigned int seed = std::random_device{}())
+      : p_bomb_(p_bomb), next_seed_(seed) {}
+
+  std::unique_ptr<Player> create_player() override {
+    return std::make_unique<GreedyNoBombPlayer>(p_bomb_, next_seed_++);
+  }
+
+private:
+  float p_bomb_;
+  unsigned int next_seed_;
+};
+
+#endif

--- a/src/players/greedy/greedy_player.h
+++ b/src/players/greedy/greedy_player.h
@@ -42,9 +42,15 @@ struct GreedyEval {
 class GreedyPlayer : public Player {
 protected:
   Move select_move_impl() override {
-    std::vector<int> legal = game_.get_legal_moves();
+    return greedy_best(game_, game_.get_legal_moves());
+  }
 
+  // Selects the best non-pass move by greedy evaluation, or pass if forced.
+  // Exposed as protected so variant subclasses can reuse it.
+  static Move greedy_best(const PartialGame &game,
+                          const std::vector<int> &legal) {
     std::vector<int> nonpass_moves;
+    nonpass_moves.reserve(legal.size());
     for (int m : legal) {
       if (Move(m).combination != Move::Combination::kPass)
         nonpass_moves.push_back(m);
@@ -54,9 +60,9 @@ protected:
       return Move(kPASS);
 
     auto best_it = nonpass_moves.begin();
-    GreedyEval best_eval = evaluate_after_move(game_, Move(*best_it));
+    GreedyEval best_eval = evaluate_after_move(game, Move(*best_it));
     for (auto it = nonpass_moves.begin() + 1; it != nonpass_moves.end(); ++it) {
-      GreedyEval eval = evaluate_after_move(game_, Move(*it));
+      GreedyEval eval = evaluate_after_move(game, Move(*it));
       if (best_eval < eval) {
         best_eval = eval;
         best_it = it;
@@ -65,7 +71,6 @@ protected:
     return Move(*best_it);
   }
 
-private:
   static GreedyEval evaluate_after_move(const PartialGame &base,
                                         const Move &move) {
     PartialGame sim = base;

--- a/src/players/greedy/greedy_random_pass_player.h
+++ b/src/players/greedy/greedy_random_pass_player.h
@@ -1,0 +1,42 @@
+#ifndef GREEDY_RANDOM_PASS_PLAYER_H
+#define GREEDY_RANDOM_PASS_PLAYER_H
+
+#include "greedy_player.h"
+
+#include <random>
+#include <vector>
+
+// Plays greedy, but with probability `p` passes instead (if pass is legal).
+// When it is the trick leader (pass not available), always plays greedy.
+class GreedyRandomPassPlayer : public GreedyPlayer {
+public:
+  explicit GreedyRandomPassPlayer(float p, unsigned int seed)
+      : p_(p), rng_(seed) {}
+
+protected:
+  Move select_move_impl() override {
+    std::vector<int> legal = game_.get_legal_moves();
+
+    bool pass_available = false;
+    for (int m : legal) {
+      if (Move(m).combination == Move::Combination::kPass) {
+        pass_available = true;
+        break;
+      }
+    }
+
+    if (pass_available) {
+      std::uniform_real_distribution<float> coin(0.0f, 1.0f);
+      if (coin(rng_) < p_)
+        return Move(kPASS);
+    }
+
+    return greedy_best(game_, legal);
+  }
+
+private:
+  float p_;
+  std::mt19937 rng_;
+};
+
+#endif

--- a/src/players/greedy/greedy_random_pass_player_factory.h
+++ b/src/players/greedy/greedy_random_pass_player_factory.h
@@ -1,0 +1,23 @@
+#ifndef GREEDY_RANDOM_PASS_PLAYER_FACTORY_H
+#define GREEDY_RANDOM_PASS_PLAYER_FACTORY_H
+
+#include "greedy_random_pass_player.h"
+#include "player_factory.h"
+
+#include <memory>
+
+class GreedyRandomPassPlayerFactory : public PlayerFactory {
+public:
+  explicit GreedyRandomPassPlayerFactory(float p, unsigned int seed = std::random_device{}())
+      : p_(p), next_seed_(seed) {}
+
+  std::unique_ptr<Player> create_player() override {
+    return std::make_unique<GreedyRandomPassPlayer>(p_, next_seed_++);
+  }
+
+private:
+  float p_;
+  unsigned int next_seed_;
+};
+
+#endif

--- a/src/players/greedy/greedy_random_player.h
+++ b/src/players/greedy/greedy_random_player.h
@@ -1,0 +1,32 @@
+#ifndef GREEDY_RANDOM_PLAYER_H
+#define GREEDY_RANDOM_PLAYER_H
+
+#include "greedy_player.h"
+
+#include <random>
+#include <vector>
+
+// Plays greedy, but with probability `p` plays a uniformly-random legal move
+// (including pass) instead.
+class GreedyRandomPlayer : public GreedyPlayer {
+public:
+  explicit GreedyRandomPlayer(float p, unsigned int seed)
+      : p_(p), rng_(seed) {}
+
+protected:
+  Move select_move_impl() override {
+    std::vector<int> legal = game_.get_legal_moves();
+    std::uniform_real_distribution<float> coin(0.0f, 1.0f);
+    if (coin(rng_) < p_) {
+      std::uniform_int_distribution<size_t> pick(0, legal.size() - 1);
+      return Move(legal[pick(rng_)]);
+    }
+    return greedy_best(game_, legal);
+  }
+
+private:
+  float p_;
+  std::mt19937 rng_;
+};
+
+#endif

--- a/src/players/greedy/greedy_random_player_factory.h
+++ b/src/players/greedy/greedy_random_player_factory.h
@@ -1,0 +1,23 @@
+#ifndef GREEDY_RANDOM_PLAYER_FACTORY_H
+#define GREEDY_RANDOM_PLAYER_FACTORY_H
+
+#include "greedy_random_player.h"
+#include "player_factory.h"
+
+#include <memory>
+
+class GreedyRandomPlayerFactory : public PlayerFactory {
+public:
+  explicit GreedyRandomPlayerFactory(float p, unsigned int seed = std::random_device{}())
+      : p_(p), next_seed_(seed) {}
+
+  std::unique_ptr<Player> create_player() override {
+    return std::make_unique<GreedyRandomPlayer>(p_, next_seed_++);
+  }
+
+private:
+  float p_;
+  unsigned int next_seed_;
+};
+
+#endif

--- a/src/players/player_factory_registry.h
+++ b/src/players/player_factory_registry.h
@@ -1,0 +1,43 @@
+#ifndef PLAYER_FACTORY_REGISTRY_H
+#define PLAYER_FACTORY_REGISTRY_H
+
+#include "player_factory.h"
+#include "greedy/greedy_player_factory.h"
+#include "greedy/greedy_random_player_factory.h"
+#include "greedy/greedy_random_pass_player_factory.h"
+#include "greedy/greedy_no_bomb_player_factory.h"
+#include "random/random_player_factory.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+// Creates a PlayerFactory by name. `param` is used by parameterized variants;
+// ignored for "random" and "greedy". `seed` is the RNG seed for stochastic players.
+//
+// Supported names:
+//   "random"             — uniform random legal move
+//   "greedy"             — greedy (no randomness)
+//   "greedy_random"      — greedy with prob param of playing a random move
+//   "greedy_random_pass" — greedy with prob param of passing instead
+//   "greedy_no_bomb"     — greedy; plays a bomb only with probability param
+inline std::shared_ptr<PlayerFactory> make_player_factory(const std::string &name,
+                                                           double param,
+                                                           unsigned int seed) {
+  if (name == "random")
+    return std::make_shared<RandomPlayerFactory>(seed);
+  if (name == "greedy")
+    return std::make_shared<GreedyPlayerFactory>();
+  if (name == "greedy_random")
+    return std::make_shared<GreedyRandomPlayerFactory>(static_cast<float>(param), seed);
+  if (name == "greedy_random_pass")
+    return std::make_shared<GreedyRandomPassPlayerFactory>(static_cast<float>(param), seed);
+  if (name == "greedy_no_bomb")
+    return std::make_shared<GreedyNoBombPlayerFactory>(static_cast<float>(param), seed);
+
+  std::cerr << "Error: unknown player '" << name << "'\n"
+            << "Available: random, greedy, greedy_random, greedy_random_pass, greedy_no_bomb\n";
+  return nullptr;
+}
+
+#endif


### PR DESCRIPTION
# Greedy variants, evaluation tooling, and docs

## Summary

Adds parameterized greedy policies, a head-to-head `eval_match` binary (paired deals + Wilson CI), round-robin and shell helpers, a shared player factory registry, and documentation updates including full rules in `RULES.md`.

## Player / engine

- **`GreedyPlayer`**: refactored `greedy_best()` for reuse; behavior unchanged (no redundant `num_3s` tiebreaker).
- **New policies** (header-only under `src/players/greedy/`):
  - `greedy_random` — with probability `param`, random legal move; else greedy.
  - `greedy_random_pass` — with probability `param`, pass when legal; else greedy.
  - `greedy_no_bomb` — when greedy would play a bomb, only do so with probability `param`; otherwise prefer pass, then best non-bomb greedy, then bomb.
- **`player_factory_registry.h`**: `make_player_factory(name, param, seed)` for `random`, `greedy`, and the three variants.

## Binaries & scripts

- **`bin/eval_match`**: two players, `--p0` / `--p1` (+ optional `--p0-param` / `--p1-param`), `--deals`, `--seed`, `--threads`; paired seating per deal; Wilson 95% CI on stdout.
- **`generate_data`**: uses the registry (`param` fixed at `0` for self-play).
- **Scripts**: `run_eval_match.sh` / `run_eval_match.py`, `analyze_eval_match.py`, `round_robin_eval.py` / `run_round_robin.sh`, JSON configs (`eval_match.json`, `round_robin_example.json`).

## Docs

- Root **`README.md`**: evaluation section, `make eval_match`, links to scripts; overview updated.
- **`RULES.md`**: human-readable Shanghainese 2-player rules (deck may differ from engine details — README defers to `src/core/` for truth).
- **`scripts/README.md`**, **`src/README.md`**, **`analysis/README.md`**, **`research/README.md`**: aligned with new tooling.

## How to test

```bash
make test_core && ./bin/test_core
make eval_match
./bin/eval_match --p0 greedy --p1 random --deals 1000 --seed 42
python3 scripts/round_robin_eval.py scripts/configs/round_robin_example.json --quiet --deals 100 --no-compile
```

## Notes

- Round-robin example uses many players (136 pairs); use `--deals` for quick smoke tests.
- `eval_match` output parsing in Python tolerates parentheses inside policy labels (e.g. `greedy_random(0.1)`).
