### PR TITLE
PIMC search players and eval tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,9 @@ generate_data: dirs $(BIN_DIR)/generate_data
 # bin/eval_match — head-to-head evaluation (no Arrow)
 # ============================================================================
 
+# PIMC stats (dets saved, etc.) printed at end of eval_match when enabled.
 $(BUILD_DIR)/src/datagen/eval_match.o: src/datagen/eval_match.cpp | dirs
-	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(INCLUDES) -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(INCLUDES) -DBIG2_PIMC_STATS=1 -c $< -o $@
 
 EVALMATCH_OBJS := $(CORE_OBJS) \
                   $(BUILD_DIR)/src/simulation/game_simulator.o \

--- a/analysis/train_tree_greedy.py
+++ b/analysis/train_tree_greedy.py
@@ -114,6 +114,28 @@ FEATURE_COLS = [
 
 assert len(FEATURE_COLS) == 61
 
+# n_3 .. n_2 in FEATURE_COLS order (matches C++ hand rank layout).
+RANK_COUNT_COLS = FEATURE_COLS[3:16]
+
+
+def ensure_derived_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Fill columns that older Parquet exports may omit (must match C++ TreeEvaluator)."""
+    if "only_single" not in df.columns:
+        missing_ranks = [c for c in RANK_COUNT_COLS if c not in df.columns]
+        if missing_ranks:
+            raise ValueError(
+                "Cannot derive only_single: missing rank columns: "
+                + ", ".join(missing_ranks)
+            )
+        df = df.copy()
+        df["only_single"] = (df[RANK_COUNT_COLS].max(axis=1) <= 1).astype(np.float32)
+        print(
+            "  Derived only_single from rank counts (column absent in Parquet — "
+            "regenerate data with only_single for consistency)"
+        )
+    return df
+
+
 # For ``bin/generate_data``: comma-separated turn features (X + labels/filters).
 TURN_FEATURES_FOR_DATAGEN = ",".join(
     FEATURE_COLS + ["turn_outcome", "next_player", "tb_case"]
@@ -414,6 +436,8 @@ def main() -> None:
     print(f"Loading {args.input} …")
     df = load_data(args.input)
     print(f"  Total rows: {len(df):,}")
+
+    df = ensure_derived_features(df)
 
     df = get_training_rows(df)
     print(f"  After last-player + TB filter: {len(df):,} rows")

--- a/scripts/configs/eval_pimc_adaptive_greedy.json
+++ b/scripts/configs/eval_pimc_adaptive_greedy.json
@@ -1,0 +1,10 @@
+{
+  "p0": "pimc_adaptive",
+  "p0_param": 50,
+  "p1": "greedy",
+  "p1_param": 0.0,
+  "deals": 500,
+  "seed": 42,
+  "threads": 8,
+  "output_log": "analysis/eval_match_last.log"
+}

--- a/scripts/configs/eval_pimc_greedy.json
+++ b/scripts/configs/eval_pimc_greedy.json
@@ -1,0 +1,10 @@
+{
+  "p0": "pimc",
+  "p0_param": 10,
+  "p1": "greedy",
+  "p1_param": 0.0,
+  "deals": 2000,
+  "seed": 42,
+  "threads": 8,
+  "output_log": "analysis/eval_match_last.log"
+}

--- a/scripts/configs/eval_pimc_tree_greedy.json
+++ b/scripts/configs/eval_pimc_tree_greedy.json
@@ -1,0 +1,10 @@
+{
+  "p0": "pimc_tree",
+  "p0_param": 10,
+  "p1": "greedy",
+  "p1_param": 0.0,
+  "deals": 2000,
+  "seed": 42,
+  "threads": 8,
+  "output_log": "analysis/eval_match_last.log"
+}

--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -9,6 +9,16 @@
 
 Game::Game() : hands_{}, hand_size_{0, 0}, current_player_(0) {}
 
+Game::Game(std::array<int, 13> hand0, std::array<int, 13> hand1,
+           std::array<int, 13> discard, Move last_move, int current_player)
+    : hands_({hand0, hand1}), discard_pile_(discard),
+      current_player_(current_player), last_move_(last_move) {
+  hand_size_[0] = 0;
+  for (int r = 0; r < 13; ++r) hand_size_[0] += hand0[r];
+  hand_size_[1] = 0;
+  for (int r = 0; r < 13; ++r) hand_size_[1] += hand1[r];
+}
+
 void Game::shuffle_deal(std::mt19937 &rng) {
   std::vector<int> deck;
   for (int r = 0; r < 13; ++r) {

--- a/src/core/game.h
+++ b/src/core/game.h
@@ -11,6 +11,11 @@ class Game {
 public:
   Game();
 
+  // Construct a Game from an explicit full state (used by PIMC rollouts).
+  // hand_size_ is derived from the hand arrays.
+  Game(std::array<int, 13> hand0, std::array<int, 13> hand1,
+       std::array<int, 13> discard, Move last_move, int current_player);
+
   void shuffle_deal(std::mt19937 &rng);
 
   int current_player() const;

--- a/src/datagen/eval_match.cpp
+++ b/src/datagen/eval_match.cpp
@@ -12,6 +12,10 @@
 #include <thread>
 #include <vector>
 
+#if BIG2_PIMC_STATS
+#include <inttypes.h>
+#endif
+
 // ============================================================================
 // Wilson score 95% confidence interval for a proportion
 // ============================================================================
@@ -232,6 +236,26 @@ int main(int argc, char **argv) {
 
   std::cout << "Elapsed: " << format_elapsed(elapsed_ms)
             << "  (" << static_cast<long>(games_per_sec) << " games/s)\n\n";
+
+#if BIG2_PIMC_STATS
+  {
+    const auto &st = pimc_global_stats();
+    const uint64_t calls = st.total_select_calls.load();
+    const uint64_t dets = st.total_dets_used.load();
+    std::fprintf(stderr,
+                 "[PIMC stats] select_calls=%" PRIu64 " total_dets=%" PRIu64
+                 " avg_dets_per_call=%.3f\n",
+                 calls, dets,
+                 calls ? static_cast<double>(dets) / static_cast<double>(calls)
+                       : 0.0);
+    std::fprintf(stderr,
+                 "[PIMC stats] total_dets_saved=%" PRIu64
+                 " rollout_equiv_saved=%" PRIu64
+                 " (candidate×det cells skipped vs n_max per call)\n",
+                 st.total_dets_saved.load(),
+                 st.total_rollout_equiv_saved.load());
+  }
+#endif
 
   return 0;
 }

--- a/src/players/pimc/pimc_adaptive_player_factory.h
+++ b/src/players/pimc/pimc_adaptive_player_factory.h
@@ -1,0 +1,31 @@
+#ifndef PIMC_ADAPTIVE_PLAYER_FACTORY_H
+#define PIMC_ADAPTIVE_PLAYER_FACTORY_H
+
+#include "pimc_player.h"
+#include "player_factory.h"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+
+// Adaptive PIMC with greedy rollout after tablebase.
+//
+// `param` — max determinizations n_max (default 10 if 0).
+// n_min   = max(3, n_max/10), clamped to n_max; delta = 0.05 (Bonferroni / M).
+class PimcAdaptivePlayerFactory : public PlayerFactory {
+public:
+  explicit PimcAdaptivePlayerFactory(double param, unsigned int seed)
+      : n_max_(std::max(1, static_cast<int>(std::round(param)))),
+        n_min_(std::min(std::max(3, n_max_ / 10), n_max_)), seed_(seed) {}
+
+  std::unique_ptr<Player> create_player() override {
+    return std::make_unique<PimcPlayer>(n_max_, n_min_, 0.05, seed_++);
+  }
+
+private:
+  int n_max_;
+  int n_min_;
+  unsigned int seed_;
+};
+
+#endif

--- a/src/players/pimc/pimc_player.h
+++ b/src/players/pimc/pimc_player.h
@@ -1,0 +1,312 @@
+#ifndef PIMC_PLAYER_H
+#define PIMC_PLAYER_H
+
+#include "game.h"
+#include "greedy/greedy_player.h"
+#include "greedy/tree_evaluator.h"
+#include "partial_game.h"
+#include "player.h"
+#include "tablebase_peek.h"
+#include "util.h"
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#if !defined(BIG2_PIMC_STATS)
+#define BIG2_PIMC_STATS 0
+#endif
+
+#if BIG2_PIMC_STATS
+#include <atomic>
+#endif
+
+// ---------------------------------------------------------------------------
+// Optional global counters (enable with -DBIG2_PIMC_STATS=1).
+// total_dets_used: sum of determinizations across all PIMC decisions.
+// total_dets_saved, total_rollout_equiv_saved: savings vs always using n_max.
+// ---------------------------------------------------------------------------
+#if BIG2_PIMC_STATS
+struct PimcGlobalStats {
+  std::atomic<uint64_t> total_select_calls{0};
+  std::atomic<uint64_t> total_dets_used{0};
+  std::atomic<uint64_t> total_dets_saved{0};
+  std::atomic<uint64_t> total_rollout_equiv_saved{0};
+};
+
+inline PimcGlobalStats &pimc_global_stats() {
+  static PimcGlobalStats s;
+  return s;
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// Hand sampler
+//
+// Returns a plausible opponent hand of size opp_count drawn uniformly from
+// the pool of cards not in my_hand and not in the discard pile.
+// Cards not drawn into the opponent hand implicitly represent the unseen pile.
+// ---------------------------------------------------------------------------
+inline std::array<int, 13>
+sample_opponent_hand(const std::array<int, 13> &my_hand,
+                     const std::array<int, 13> &discard, int opp_count,
+                     std::mt19937 &rng) {
+  std::vector<int> pool;
+  pool.reserve(16);
+  for (int r = 0; r < 13; ++r) {
+    int available = max_cards_in_deck_for_rank(r) - my_hand[r] - discard[r];
+    for (int i = 0; i < available; ++i)
+      pool.push_back(r);
+  }
+
+  std::array<int, 13> opp_hand{};
+  int pool_size = static_cast<int>(pool.size());
+  for (int i = 0; i < opp_count && i < pool_size; ++i) {
+    std::uniform_int_distribution<int> dist(i, pool_size - 1);
+    int j = dist(rng);
+    std::swap(pool[i], pool[j]);
+    opp_hand[pool[i]]++;
+  }
+  return opp_hand;
+}
+
+// ---------------------------------------------------------------------------
+// Hoeffding confidence: Bonferroni delta' = delta / M; symmetric radius
+// r = sqrt(log(2/delta') / (2n)) for [0,1] means.
+// Batched: scalar r, vector p_i = wins[i]/n, lower_i = p_i - r, upper_i = p_i + r.
+// Stop if some arm b has lower[b] > max_{j!=b} upper[j] (unique top count).
+// ---------------------------------------------------------------------------
+inline bool confident_leader_hoeffding(const std::vector<int> &wins, int n, int M,
+                                       double delta) {
+  if (n < 1 || M < 2)
+    return false;
+
+  int max_w = wins[0];
+  for (int i = 1; i < M; ++i) {
+    if (wins[i] > max_w)
+      max_w = wins[i];
+  }
+  int leader_count = 0;
+  int b = 0;
+  for (int i = 0; i < M; ++i) {
+    if (wins[i] == max_w) {
+      ++leader_count;
+      b = i;
+    }
+  }
+  if (leader_count != 1)
+    return false;
+
+  const double delta_prime = delta / static_cast<double>(M);
+  if (delta_prime <= 0.0 || delta_prime >= 1.0)
+    return false;
+
+  const double r =
+      std::sqrt(std::log(2.0 / delta_prime) / (2.0 * static_cast<double>(n)));
+  const double inv_n = 1.0 / static_cast<double>(n);
+
+  double max_upper_other = -1.0;
+  for (int j = 0; j < M; ++j) {
+    if (j == b)
+      continue;
+    const double pj = static_cast<double>(wins[j]) * inv_n;
+    const double upper = pj + r;
+    if (upper > max_upper_other)
+      max_upper_other = upper;
+  }
+
+  const double pb = static_cast<double>(wins[b]) * inv_n;
+  const double lower_b = pb - r;
+  return lower_b > max_upper_other;
+}
+
+// ---------------------------------------------------------------------------
+// Rollout policy: mirrors Player::select_move order.
+// ---------------------------------------------------------------------------
+template <typename EvalFn>
+inline int policy_rollout(Game g, int my_player, EvalFn eval_fn) {
+  while (!g.is_over()) {
+    int cp = g.current_player();
+    PartialGame pg(g, cp);
+    TablebasePeekResult tb = peek_tablebase_move(pg);
+    if (tb.move) {
+      g.apply_move(*tb.move);
+    } else {
+      Move best = greedy_best(pg, pg.get_legal_moves(), eval_fn);
+      g.apply_move(best);
+    }
+  }
+  return g.get_winner() == my_player ? 1 : 0;
+}
+
+// Shared PIMC move selection.
+//
+// Common random numbers (CRN): one opponent hand per det, all candidates scored.
+//
+// If adaptive: loop up to n_max; after n_min dets, stop early when
+// confident_leader_hoeffding fires. If not adaptive: exactly n_max dets.
+template <typename EvalFn>
+inline Move pimc_select_move_impl(const PartialGame &game_, int player_num_,
+                                  int n_max, int n_min, bool adaptive,
+                                  double delta, std::mt19937 &rng_,
+                                  EvalFn eval_fn) {
+  const std::vector<int> legal = game_.get_legal_moves();
+
+  std::vector<int> candidates;
+  candidates.reserve(legal.size());
+  bool has_pass = false;
+  for (int mid : legal) {
+    if (Move(mid).combination == Move::Combination::kPass)
+      has_pass = true;
+    else
+      candidates.push_back(mid);
+  }
+
+  if (candidates.empty())
+    return Move(kPASS);
+
+  if (has_pass)
+    candidates.push_back(kPASS);
+
+  const std::array<int, 13> my_hand = game_.player_hand();
+  const std::array<int, 13> discard = game_.discard_pile();
+  const int opp_count = game_.opponent_hand_size();
+  const Move last_mv = game_.last_move();
+
+  const int M = static_cast<int>(candidates.size());
+  std::vector<int> wins(M, 0);
+
+#if BIG2_PIMC_STATS
+  pimc_global_stats().total_select_calls += 1;
+#endif
+
+  int dets_used = 0;
+  for (int det = 0; det < n_max; ++det) {
+    const std::array<int, 13> opp_hand =
+        sample_opponent_hand(my_hand, discard, opp_count, rng_);
+
+    const std::array<int, 13> hand0 =
+        (player_num_ == 0) ? my_hand : opp_hand;
+    const std::array<int, 13> hand1 =
+        (player_num_ == 0) ? opp_hand : my_hand;
+
+    for (int ci = 0; ci < M; ++ci) {
+      Game g(hand0, hand1, discard, last_mv, player_num_);
+      g.apply_move(candidates[ci]);
+      wins[ci] += policy_rollout(g, player_num_, eval_fn);
+    }
+
+    dets_used = det + 1;
+
+    if (adaptive && dets_used >= n_min) {
+      if (M == 1)
+        break;
+      if (confident_leader_hoeffding(wins, dets_used, M, delta))
+        break;
+    }
+  }
+
+#if BIG2_PIMC_STATS
+  pimc_global_stats().total_dets_used += static_cast<uint64_t>(dets_used);
+  if (adaptive) {
+    const uint64_t saved =
+        static_cast<uint64_t>(n_max - dets_used);
+    pimc_global_stats().total_dets_saved += saved;
+    pimc_global_stats().total_rollout_equiv_saved +=
+        saved * static_cast<uint64_t>(M);
+  }
+#endif
+
+  int best_ci = 0;
+  for (int ci = 1; ci < M; ++ci) {
+    if (wins[ci] > wins[best_ci])
+      best_ci = ci;
+    else if (wins[ci] == wins[best_ci] && candidates[ci] < candidates[best_ci])
+      best_ci = ci;
+  }
+  return Move(candidates[best_ci]);
+}
+
+// ---------------------------------------------------------------------------
+// PimcPlayer — greedy heuristic rollout (after tablebase).
+// ---------------------------------------------------------------------------
+class PimcPlayer : public Player {
+public:
+  // Fixed N determinizations (legacy).
+  explicit PimcPlayer(int num_samples, unsigned int seed)
+      : n_max_(num_samples), n_min_(0), delta_(0.05), adaptive_(false),
+        rng_(seed) {}
+
+  // Adaptive: up to n_max dets; stop early after n_min when Hoeffding test passes.
+  PimcPlayer(int n_max, int n_min, double delta, unsigned int seed)
+      : n_max_(n_max), n_min_(n_min), delta_(delta), adaptive_(true),
+        rng_(seed) {}
+
+protected:
+  void on_deal(const std::array<int, 13> & /*hand*/, int player_num) override {
+    player_num_ = player_num;
+  }
+
+  Move select_move_impl() override {
+    return pimc_select_move_impl(game_, player_num_, n_max_, n_min_, adaptive_,
+                                 delta_, rng_, greedy_hand_eval);
+  }
+
+private:
+  int n_max_;
+  int n_min_;
+  double delta_;
+  bool adaptive_;
+  int player_num_{0};
+  std::mt19937 rng_;
+};
+
+// ---------------------------------------------------------------------------
+// PimcTreePlayer — tree evaluator rollout (after tablebase).
+// ---------------------------------------------------------------------------
+class PimcTreePlayer : public Player {
+public:
+  PimcTreePlayer(int num_samples, const std::string &model_path,
+                 unsigned int seed)
+      : n_max_(num_samples), n_min_(0), delta_(0.05), adaptive_(false),
+        evaluator_(model_path), rng_(seed) {
+    if (!evaluator_.loaded())
+      throw std::runtime_error("PimcTreePlayer: model failed to load from '" +
+                               model_path + "'");
+  }
+
+  PimcTreePlayer(int n_max, int n_min, double delta,
+                 const std::string &model_path, unsigned int seed)
+      : n_max_(n_max), n_min_(n_min), delta_(delta), adaptive_(true),
+        evaluator_(model_path), rng_(seed) {
+    if (!evaluator_.loaded())
+      throw std::runtime_error("PimcTreePlayer: model failed to load from '" +
+                               model_path + "'");
+  }
+
+protected:
+  void on_deal(const std::array<int, 13> & /*hand*/, int player_num) override {
+    player_num_ = player_num;
+  }
+
+  Move select_move_impl() override {
+    return pimc_select_move_impl(
+        game_, player_num_, n_max_, n_min_, adaptive_, delta_, rng_,
+        [this](const PartialGame &sim) { return evaluator_.predict(sim); });
+  }
+
+private:
+  int n_max_;
+  int n_min_;
+  double delta_;
+  bool adaptive_;
+  int player_num_{0};
+  TreeEvaluator evaluator_;
+  std::mt19937 rng_;
+};
+
+#endif

--- a/src/players/pimc/pimc_player_factory.h
+++ b/src/players/pimc/pimc_player_factory.h
@@ -1,0 +1,32 @@
+#ifndef PIMC_PLAYER_FACTORY_H
+#define PIMC_PLAYER_FACTORY_H
+
+#include "pimc_player.h"
+#include "player_factory.h"
+
+#include <cmath>
+#include <memory>
+
+// Factory for PimcPlayer.
+//
+// `param` is the number of determinization samples N.
+// `seed`  is the RNG seed for the player's hand sampler.
+//
+// Example round-robin config entry:
+//   {"type": "pimc", "param": 10, "label": "pimc_n10"}
+class PimcPlayerFactory : public PlayerFactory {
+public:
+  explicit PimcPlayerFactory(double param, unsigned int seed)
+      : num_samples_(std::max(1, static_cast<int>(std::round(param)))),
+        seed_(seed) {}
+
+  std::unique_ptr<Player> create_player() override {
+    return std::make_unique<PimcPlayer>(num_samples_, seed_++);
+  }
+
+private:
+  int num_samples_;
+  unsigned int seed_;
+};
+
+#endif

--- a/src/players/pimc/pimc_tree_adaptive_player_factory.h
+++ b/src/players/pimc/pimc_tree_adaptive_player_factory.h
@@ -1,0 +1,36 @@
+#ifndef PIMC_TREE_ADAPTIVE_PLAYER_FACTORY_H
+#define PIMC_TREE_ADAPTIVE_PLAYER_FACTORY_H
+
+#include "pimc_player.h"
+#include "player_factory.h"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <string>
+
+// Adaptive PIMC with tree rollout after tablebase (data/tree_model_d{depth}.txt).
+//
+// `param` — max determinizations n_max (default 10 if 0).
+// `tree_depth` — model file depth (e.g. 10).
+class PimcTreeAdaptivePlayerFactory : public PlayerFactory {
+public:
+  PimcTreeAdaptivePlayerFactory(double param, int tree_depth, unsigned int seed)
+      : n_max_(std::max(1, static_cast<int>(std::round(param)))),
+        n_min_(std::min(std::max(3, n_max_ / 10), n_max_)),
+        model_path_("data/tree_model_d" + std::to_string(tree_depth) + ".txt"),
+        seed_(seed) {}
+
+  std::unique_ptr<Player> create_player() override {
+    return std::make_unique<PimcTreePlayer>(n_max_, n_min_, 0.05, model_path_,
+                                              seed_++);
+  }
+
+private:
+  int n_max_;
+  int n_min_;
+  std::string model_path_;
+  unsigned int seed_;
+};
+
+#endif

--- a/src/players/pimc/pimc_tree_player_factory.h
+++ b/src/players/pimc/pimc_tree_player_factory.h
@@ -1,0 +1,35 @@
+#ifndef PIMC_TREE_PLAYER_FACTORY_H
+#define PIMC_TREE_PLAYER_FACTORY_H
+
+#include "pimc_player.h"
+#include "player_factory.h"
+
+#include <cmath>
+#include <memory>
+#include <string>
+
+// Factory for PimcTreePlayer (PIMC with decision-tree rollout after tablebase).
+//
+// `param`     — number of determinization samples N (default 10 if 0).
+// `tree_depth`— which `data/tree_model_d{tree_depth}.txt` to load (e.g. 10).
+// `seed`      — RNG seed for hand sampling.
+//
+// Example: {"type": "pimc_tree", "param": 10, "label": "pimc_tree_n10_d10"}
+class PimcTreePlayerFactory : public PlayerFactory {
+public:
+  PimcTreePlayerFactory(double param, int tree_depth, unsigned int seed)
+      : num_samples_(std::max(1, static_cast<int>(std::round(param)))),
+        model_path_("data/tree_model_d" + std::to_string(tree_depth) + ".txt"),
+        seed_(seed) {}
+
+  std::unique_ptr<Player> create_player() override {
+    return std::make_unique<PimcTreePlayer>(num_samples_, model_path_, seed_++);
+  }
+
+private:
+  int num_samples_;
+  std::string model_path_;
+  unsigned int seed_;
+};
+
+#endif

--- a/src/players/player_factory_registry.h
+++ b/src/players/player_factory_registry.h
@@ -7,6 +7,10 @@
 #include "greedy/greedy_random_pass_player_factory.h"
 #include "greedy/greedy_no_bomb_player_factory.h"
 #include "greedy/tree_greedy_player_factory.h"
+#include "pimc/pimc_adaptive_player_factory.h"
+#include "pimc/pimc_player_factory.h"
+#include "pimc/pimc_tree_adaptive_player_factory.h"
+#include "pimc/pimc_tree_player_factory.h"
 #include "random/random_player_factory.h"
 
 #include <iostream>
@@ -24,6 +28,11 @@
 //   "greedy_no_bomb"     — greedy; plays a bomb only with probability param
 //   "tree_greedy"        — greedy with decision-tree evaluator; param = model depth
 //                          (loads data/tree_model_d{int(param)}.txt)
+//   "pimc"               — PIMC; greedy rollout after TB; param = samples N (default 10)
+//   "pimc_tree"          — PIMC; tree rollout after TB; param = N;
+//                          loads data/tree_model_d10.txt (depth 10)
+//   "pimc_adaptive"      — PIMC + Hoeffding early stop; param = n_max (default 10)
+//   "pimc_tree_adaptive" — same with tree rollout; depth 10 model file
 inline std::shared_ptr<PlayerFactory> make_player_factory(const std::string &name,
                                                            double param,
                                                            unsigned int seed) {
@@ -39,10 +48,22 @@ inline std::shared_ptr<PlayerFactory> make_player_factory(const std::string &nam
     return std::make_shared<GreedyNoBombPlayerFactory>(static_cast<float>(param), seed);
   if (name == "tree_greedy")
     return std::make_shared<TreeGreedyPlayerFactory>(param);
+  if (name == "pimc")
+    return std::make_shared<PimcPlayerFactory>(param == 0.0 ? 10.0 : param, seed);
+  if (name == "pimc_tree")
+    return std::make_shared<PimcTreePlayerFactory>(param == 0.0 ? 10.0 : param, 10,
+                                                     seed);
+  if (name == "pimc_adaptive")
+    return std::make_shared<PimcAdaptivePlayerFactory>(param == 0.0 ? 10.0 : param,
+                                                        seed);
+  if (name == "pimc_tree_adaptive")
+    return std::make_shared<PimcTreeAdaptivePlayerFactory>(
+        param == 0.0 ? 10.0 : param, 10, seed);
 
   std::cerr << "Error: unknown player '" << name << "'\n"
             << "Available: random, greedy, greedy_random, greedy_random_pass, "
-               "greedy_no_bomb, tree_greedy\n";
+               "greedy_no_bomb, tree_greedy, pimc, pimc_tree, pimc_adaptive, "
+               "pimc_tree_adaptive\n";
   return nullptr;
 }
 


### PR DESCRIPTION
## Summary

- Add PIMC (Perfect Information Monte Carlo) with greedy and decision-tree rollouts after tablebase; optional adaptive early stop via Hoeffding bounds.
- Register players: `pimc`, `pimc_tree`, `pimc_adaptive`, `pimc_tree_adaptive` in the factory registry.
- Add explicit `Game` constructor for reconstructing full states from sampled opponent hands.
- `eval_match`: optional PIMC aggregate stats when built with `-DBIG2_PIMC_STATS=1` (enabled for `eval_match.o` in the Makefile).
- `train_tree_greedy.py`: derive `only_single` when missing from older Parquet exports.
- Add JSON eval configs for PIMC vs greedy baselines.

## Test plan

- [ ] `make eval_match test_core`
- [ ] Spot-check `./bin/eval_match` with `pimc` / `pimc_adaptive` vs `greedy`

Made with [Cursor](https://cursor.com)