### PR TITLE
PIMC profiling: script, prof/ ignore, eval_match --games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ build/
 data/
 venv/
 
+# profiling (perf + callgrind from scripts/profile_pimc_selfplay.sh)
+prof/
+perf.data*
+perf.data.old*
+
 # Object files
 *.o
 *.obj

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ help:
 	@echo "  make coordinator          - coordinator + Parquet objects (needs libarrow)"
 	@echo "  make generate_data        - self-play + Parquet + stats (needs libarrow)"
 	@echo "  make eval_match           - head-to-head evaluation binary (no Arrow)"
+	@echo "  scripts/profile_pimc_selfplay.sh - PIMC(20) symmetric eval_match: perf/callgrind/plain"
 	@echo "  make pass_greedy_datagen  - CSV dataset for pass-vs-greedy logistic (no Arrow)"
 	@echo "  make move_agreement       - greedy vs tree move agreement stats (no Arrow)"
 	@echo "  make tablebase_opp1_gen   - build opp-1-card tablebase binary generator (no Arrow)"

--- a/scripts/profile_pimc_selfplay.sh
+++ b/scripts/profile_pimc_selfplay.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # PIMC(20) vs PIMC(20) eval_match profiling helper.
 #
-# Uses a fixed seed (default 42) so deal order and positions match across builds.
+# Default: independent games (--games) — each index uses RNG seed+N for more
+# position diversity than paired deals. Optional: --paired-deals for classical
+# eval_match paired mode (--deals, 2*N total games).
 #
 # Usage:
 #   ./scripts/profile_pimc_selfplay.sh --mode perf
 #   ./scripts/profile_pimc_selfplay.sh --mode callgrind --target-seconds 180
-#   ./scripts/profile_pimc_selfplay.sh --mode perf --mode plain --perf-record
-#   ./scripts/profile_pimc_selfplay.sh --mode perf --deals 1200    # skip calibration
+#   ./scripts/profile_pimc_selfplay.sh --mode perf --paired-deals 600   # paired mode
 #
 set -euo pipefail
 
@@ -25,7 +26,10 @@ MODES=()
 SEED="$DEFAULT_SEED"
 TARGET_SEC="$DEFAULT_TARGET_SEC"
 THREADS="$DEFAULT_THREADS"
-FIXED_DEALS=""
+# Fixed workload count (--games or --paired-deals overrides calibration)
+FIXED=""
+USE_PAIRED_DEALS=false
+WORKLOAD_CLI_COUNT=0
 PROBE_PERF="$DEFAULT_PROBE_PERF"
 PROBE_CALLGRIND="$DEFAULT_PROBE_CALLGRIND"
 DO_BUILD=true
@@ -34,32 +38,48 @@ PERF_DATA="${ROOT}/prof/perf.data"
 CALLGRIND_OUT="${ROOT}/prof/callgrind_pimc20.out"
 CALL_GRAPH="dwarf"
 
+declare -a WAL=()
+
+# eval_match workload: --games (default) or --paired-deals → --deals
+populate_workload_argv() {
+  if "$USE_PAIRED_DEALS"; then
+    WAL=(--deals "$1")
+  else
+    WAL=(--games "$1")
+  fi
+}
+
 usage() {
   cat <<'HDR'
-Symmetric PIMC(20) self-play profiler (runs bin/eval_match). Fixed default seed keeps
-deal order repeatable across optimizations.
+Symmetric PIMC(20) eval_match profiler.
+
+Default workload: independent full games (--games), seed+N per game — more move
+variety than paired deals. Fixed default seed (--seed 42) keeps work repeatable.
 
 HDR
   cat <<EOF
 Required (at least once):
   --mode perf|--mode callgrind|--mode plain
 
-Optional:
-  --seed N                   RNG base seed for eval_match (default: ${DEFAULT_SEED})
-  --target-seconds N         Calibration wall-time target seconds (default: ${DEFAULT_TARGET_SEC})
-  --threads N                Worker threads (default: ${DEFAULT_THREADS}; use 1 for profiling)
-  --deals N                  Skip calibration; run exactly N unique deals per mode
-  --probe-perf-deals N       Probe size for perf/plain calibration (default: ${DEFAULT_PROBE_PERF})
-  --probe-callgrind-deals N  Probe size for callgrind (default: ${DEFAULT_PROBE_CALLGRIND})
-  --no-build                 Skip 'make eval_match'
-  --perf-record              Run 'perf record' (-g --call-graph) instead of perf stat
-  --perf-data PATH           Output for perf.data (default: repo/prof/perf.data)
-  --callgrind-out PATH       Callgrind outfile (default: repo/prof/callgrind_pimc20.out)
-  --call-graph STYLE         dwarf|fp when using --perf-record (default: ${CALL_GRAPH})
+Workload (default independent games):
+  (no workload flag)           Calibrated --games count from probe timing
+  --games N                    Skip calibration; exactly N independent games
+  --paired-deals N             Paired-eval mode (--deals N ⇒ 2*N total games)
 
-Rebuild tip (better stacks):  make clean && CXXFLAGS='-O2 -g' make eval_match
+Additional options:
+  --seed N                     Base seed (default: ${DEFAULT_SEED})
+  --target-seconds N           Calibration target seconds (default: ${DEFAULT_TARGET_SEC})
+  --threads N                  (default: ${DEFAULT_THREADS}; use 1 when profiling)
+  --probe-perf N               Probe size for perf/plain calibration (default: ${DEFAULT_PROBE_PERF})
+  --probe-callgrind N          Probe size for callgrind (default: ${DEFAULT_PROBE_CALLGRIND})
+  --no-build                   Skip make eval_match
+  --perf-record                perf record (-g --call-graph) instead of perf stat
+  --perf-data PATH             (default: ${PERF_DATA})
+  --callgrind-out PATH         (default: ${CALLGRIND_OUT})
+  --call-graph STYLE           dwarf|fp when using --perf-record (default: ${CALL_GRAPH})
 
-perf may need:  sudo sysctl kernel.perf_event_paranoid=1
+Rebuild tip:  make clean && CXXFLAGS='-O2 -g' make eval_match
+perf sysctl:   sudo sysctl kernel.perf_event_paranoid=1
 EOF
 }
 
@@ -85,18 +105,27 @@ while [[ $# -gt 0 ]]; do
       THREADS="$2"
       shift 2
       ;;
-    --deals)
-      [[ $# -ge 2 ]] || { echo "error: --deals requires a value"; exit 1; }
-      FIXED_DEALS="$2"
+    --games)
+      [[ $# -ge 2 ]] || { echo "error: --games requires a value"; exit 1; }
+      FIXED="$2"
+      USE_PAIRED_DEALS=false
+      WORKLOAD_CLI_COUNT=$((WORKLOAD_CLI_COUNT + 1))
       shift 2
       ;;
-    --probe-perf-deals)
-      [[ $# -ge 2 ]] || { echo "error: --probe-perf-deals requires a value"; exit 1; }
+    --paired-deals)
+      [[ $# -ge 2 ]] || { echo "error: --paired-deals requires a value"; exit 1; }
+      FIXED="$2"
+      USE_PAIRED_DEALS=true
+      WORKLOAD_CLI_COUNT=$((WORKLOAD_CLI_COUNT + 1))
+      shift 2
+      ;;
+    --probe-perf|--probe-perf-deals)
+      [[ $# -ge 2 ]] || { echo "error: $1 requires a value"; exit 1; }
       PROBE_PERF="$2"
       shift 2
       ;;
-    --probe-callgrind-deals)
-      [[ $# -ge 2 ]] || { echo "error: --probe-callgrind-deals requires a value"; exit 1; }
+    --probe-callgrind|--probe-callgrind-deals)
+      [[ $# -ge 2 ]] || { echo "error: $1 requires a value"; exit 1; }
       PROBE_CALLGRIND="$2"
       shift 2
       ;;
@@ -132,23 +161,31 @@ done
   exit 1
 }
 
+if [[ "$WORKLOAD_CLI_COUNT" -gt 1 ]]; then
+  echo "error: use at most one of --games or --paired-deals" >&2
+  exit 1
+fi
+
 if "$DO_BUILD"; then
   make -C "$ROOT" eval_match
 fi
 
 if [[ ! -x "$EXE" ]]; then
-  echo "error: missing executable ${BIN_REL}; run make eval_match from repo root." >&2
+  echo "error: missing executable ${BIN_REL}; run make eval_match." >&2
   exit 1
 fi
 
 mkdir -p "${ROOT}/prof"
 
+# shellcheck disable=SC2086
 elapsed_sec_plain() {
-  local deals="$1"
+  local n="$1"
+  populate_workload_argv "$n"
+
   if [[ "${BASH_VERSINFO[0]}" -ge 5 ]]; then
     local start="$EPOCHREALTIME"
-    "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
-      --deals "$deals" --seed "$SEED" --threads "$THREADS" \
+    "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 "${WAL[@]}" \
+      --seed "$SEED" --threads "$THREADS" \
       >/dev/null 2>&1
     local end="$EPOCHREALTIME"
     awk -v a="$start" -v b="$end" 'BEGIN { printf "%f\n", (b > a ? b - a : 1e-9) }'
@@ -163,29 +200,27 @@ elapsed_sec_plain() {
       system $exe, @args and exit($? >> 8);
       open(STDOUT, ">&", $bak);
       printf "%f\n", time() - $t0;
-    ' "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
-      --deals "$deals" --seed "$SEED" --threads "$THREADS"
+    ' "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 "${WAL[@]}" \
+      --seed "$SEED" --threads "$THREADS"
   fi
 }
 
-# negligible vs plain; extrapolate perf-sized runs from plain probe time
 elapsed_sec_perf_stat() {
   elapsed_sec_plain "$1"
 }
 
 elapsed_sec_callgrind() {
-  local deals="$1"
+  local n="$1"
+  populate_workload_argv "$n"
   valgrind --tool=callgrind --instr-atstart=yes --quiet \
     --callgrind-out-file=/dev/null -- \
-    "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
-      --deals "$deals" --seed "$SEED" --threads "$THREADS" \
+    "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 "${WAL[@]}" \
+    --seed "$SEED" --threads "$THREADS" \
     >/dev/null 2>&1
 }
 
-scale_deals_from_probe() {
-  local probe="$1"
-  local t_probe="$2"
-  awk -v p="$probe" -v targ="$TARGET_SEC" -v t="$t_probe" '
+scale_from_probe() {
+  awk -v p="$1" -v targ="$TARGET_SEC" -v t="$2" '
     BEGIN {
       if (t <= 0) t = 1e-9;
       x = int(p * targ / t + 0.5);
@@ -195,35 +230,43 @@ scale_deals_from_probe() {
   ' </dev/null
 }
 
-resolve_deals() {
+workload_descr() {
+  if "$USE_PAIRED_DEALS"; then
+    echo "paired deals (total games=$((2 * $1)))"
+  else
+    echo "independent games ($(($1)))"
+  fi
+}
+
+resolve_workload_units() {
   local kind="$1"
   local probe="$2"
 
-  if [[ "$FIXED_DEALS" != "" ]]; then
-    echo "$FIXED_DEALS"
+  if [[ "$FIXED" != "" ]]; then
+    echo "$FIXED"
     return
   fi
 
   if [[ "$probe" -lt 1 ]]; then
-    echo "error: probe deals must be >= 1 ($kind)" >&2
+    echo "error: probe must be >= 1 ($kind)" >&2
     exit 1
   fi
 
-  echo "Calib ($kind): probe deals=${probe}, seed=${SEED}, threads=${THREADS}" >&2
+  echo "Calib ($kind): probe units=${probe} ($(workload_descr "$probe")), seed=${SEED}, threads=${THREADS}" >&2
   local t_probe
   case "$kind" in
     plain) t_probe="$(elapsed_sec_plain "$probe")" ;;
     perf) t_probe="$(elapsed_sec_perf_stat "$probe")" ;;
     callgrind)
       command -v valgrind >/dev/null 2>&1 || {
-        echo "error: callgrind requested but valgrind not in PATH" >&2
+        echo "error: valgrind not in PATH" >&2
         exit 1
       }
       t_probe="$(elapsed_sec_callgrind "$probe")"
       ;;
   esac
-  echo "(probe wall ${t_probe}s) -> extrapolating to ~${TARGET_SEC}s target ..." >&2
-  scale_deals_from_probe "$probe" "$t_probe"
+  echo "(probe wall ${t_probe}s) -> extrapolating to ~${TARGET_SEC}s ..." >&2
+  scale_from_probe "$probe" "$t_probe"
 }
 
 require_perf() {
@@ -233,37 +276,44 @@ require_perf() {
   }
 }
 
+populate_wald() {
+  populate_workload_argv "$1"
+}
+
 run_mode_plain() {
-  local deals="$1"
-  echo "plain: deals=$deals  total_games=$((2 * deals))  seed=$SEED  threads=$THREADS" >&2
+  local units="$1"
+  populate_wald "$units"
+  echo "plain: $(workload_descr "$units"), seed=${SEED} threads=${THREADS}" >&2
   SECONDS=0
-  "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
-    --deals "$deals" --seed "$SEED" --threads "$THREADS"
+  "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 "${WAL[@]}" \
+    --seed "$SEED" --threads "$THREADS"
   echo "(plain wall-clock ~ ${SECONDS}s via bash \$SECONDS; see eval_match games/s)" >&2
 }
 
 run_mode_perf() {
-  local deals="$1"
-  echo "perf: deals=$deals  total_games=$((2 * deals))  seed=$SEED  threads=$THREADS" >&2
+  local units="$1"
+  populate_wald "$units"
+  echo "perf: $(workload_descr "$units"), seed=${SEED} threads=${THREADS}" >&2
   mkdir -p "$(dirname "${PERF_DATA}")"
   require_perf
 
   if "$PERF_RECORD"; then
     echo "Recording to ${PERF_DATA} (--call-graph ${CALL_GRAPH})" >&2
     perf record --output="${PERF_DATA}" -g --call-graph "${CALL_GRAPH}" -- \
-      "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
-      --deals "$deals" --seed "$SEED" --threads "$THREADS"
-    echo "perf report -i '${PERF_DATA}'" >&2
+      "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 "${WAL[@]}" \
+      --seed "$SEED" --threads "$THREADS"
+    echo "Inspect: perf report -i '${PERF_DATA}'" >&2
   else
     perf stat -r 1 -- \
-      "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
-      --deals "$deals" --seed "$SEED" --threads "$THREADS"
+      "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 "${WAL[@]}" \
+      --seed "$SEED" --threads "$THREADS"
   fi
 }
 
 run_mode_callgrind() {
-  local deals="$1"
-  echo "callgrind: deals=$deals  total_games=$((2 * deals))  seed=$SEED  threads=$THREADS" >&2
+  local units="$1"
+  populate_wald "$units"
+  echo "callgrind: $(workload_descr "$units"), seed=${SEED} threads=${THREADS}" >&2
   mkdir -p "$(dirname "${CALLGRIND_OUT}")"
   command -v valgrind >/dev/null 2>&1 || {
     echo "error: valgrind not in PATH" >&2
@@ -272,9 +322,9 @@ run_mode_callgrind() {
   echo "Writing ${CALLGRIND_OUT}" >&2
   valgrind --tool=callgrind --instr-atstart=yes \
     --callgrind-out-file="${CALLGRIND_OUT}" -- \
-    "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
-    --deals "$deals" --seed "$SEED" --threads "$THREADS"
-  echo "KCachegrind / qcachegrind: ${CALLGRIND_OUT}" >&2
+    "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 "${WAL[@]}" \
+    --seed "$SEED" --threads "$THREADS"
+  echo "Open in KCachegrind: ${CALLGRIND_OUT}" >&2
 }
 
 declare -A DID=()
@@ -284,7 +334,7 @@ for m in "${MODES[@]}"; do
     perf | callgrind | plain)
       ;;
     *)
-      echo "error: unknown mode '${m}' (use perf | callgrind | plain)" >&2
+      echo "error: unknown mode '${m}'" >&2
       exit 1
       ;;
   esac
@@ -294,23 +344,21 @@ for m in "${MODES[@]}"; do
   [[ "${DID[$m]:-}" ]] && continue
   DID["$m"]=1
 
-  deals=""
   echo ""
   echo "================ ${m} ================="
   case "$m" in
     plain)
-      deals="$(resolve_deals plain "${PROBE_PERF}")"
-      run_mode_plain "$deals"
+      units="$(resolve_workload_units plain "${PROBE_PERF}")"
+      run_mode_plain "$units"
       ;;
     perf)
       require_perf
-      deals="$(resolve_deals perf "${PROBE_PERF}")"
-      run_mode_perf "$deals"
+      units="$(resolve_workload_units perf "${PROBE_PERF}")"
+      run_mode_perf "$units"
       ;;
     callgrind)
-      deals="$(resolve_deals callgrind "${PROBE_CALLGRIND}")"
-      run_mode_callgrind "$deals"
+      units="$(resolve_workload_units callgrind "${PROBE_CALLGRIND}")"
+      run_mode_callgrind "$units"
       ;;
   esac
 done
-

--- a/scripts/profile_pimc_selfplay.sh
+++ b/scripts/profile_pimc_selfplay.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# PIMC(20) vs PIMC(20) eval_match profiling helper.
+#
+# Uses a fixed seed (default 42) so deal order and positions match across builds.
+#
+# Usage:
+#   ./scripts/profile_pimc_selfplay.sh --mode perf
+#   ./scripts/profile_pimc_selfplay.sh --mode callgrind --target-seconds 180
+#   ./scripts/profile_pimc_selfplay.sh --mode perf --mode plain --perf-record
+#   ./scripts/profile_pimc_selfplay.sh --mode perf --deals 1200    # skip calibration
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN_REL="bin/eval_match"
+EXE="${ROOT}/${BIN_REL}"
+
+DEFAULT_SEED=42
+DEFAULT_TARGET_SEC=150
+DEFAULT_THREADS=1
+DEFAULT_PROBE_PERF=5
+DEFAULT_PROBE_CALLGRIND=1
+
+MODES=()
+SEED="$DEFAULT_SEED"
+TARGET_SEC="$DEFAULT_TARGET_SEC"
+THREADS="$DEFAULT_THREADS"
+FIXED_DEALS=""
+PROBE_PERF="$DEFAULT_PROBE_PERF"
+PROBE_CALLGRIND="$DEFAULT_PROBE_CALLGRIND"
+DO_BUILD=true
+PERF_RECORD=false
+PERF_DATA="${ROOT}/prof/perf.data"
+CALLGRIND_OUT="${ROOT}/prof/callgrind_pimc20.out"
+CALL_GRAPH="dwarf"
+
+usage() {
+  cat <<'HDR'
+Symmetric PIMC(20) self-play profiler (runs bin/eval_match). Fixed default seed keeps
+deal order repeatable across optimizations.
+
+HDR
+  cat <<EOF
+Required (at least once):
+  --mode perf|--mode callgrind|--mode plain
+
+Optional:
+  --seed N                   RNG base seed for eval_match (default: ${DEFAULT_SEED})
+  --target-seconds N         Calibration wall-time target seconds (default: ${DEFAULT_TARGET_SEC})
+  --threads N                Worker threads (default: ${DEFAULT_THREADS}; use 1 for profiling)
+  --deals N                  Skip calibration; run exactly N unique deals per mode
+  --probe-perf-deals N       Probe size for perf/plain calibration (default: ${DEFAULT_PROBE_PERF})
+  --probe-callgrind-deals N  Probe size for callgrind (default: ${DEFAULT_PROBE_CALLGRIND})
+  --no-build                 Skip 'make eval_match'
+  --perf-record              Run 'perf record' (-g --call-graph) instead of perf stat
+  --perf-data PATH           Output for perf.data (default: repo/prof/perf.data)
+  --callgrind-out PATH       Callgrind outfile (default: repo/prof/callgrind_pimc20.out)
+  --call-graph STYLE         dwarf|fp when using --perf-record (default: ${CALL_GRAPH})
+
+Rebuild tip (better stacks):  make clean && CXXFLAGS='-O2 -g' make eval_match
+
+perf may need:  sudo sysctl kernel.perf_event_paranoid=1
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      [[ $# -ge 2 ]] || { echo "error: --mode requires a value"; exit 1; }
+      MODES+=("$2")
+      shift 2
+      ;;
+    --seed)
+      [[ $# -ge 2 ]] || { echo "error: --seed requires a value"; exit 1; }
+      SEED="$2"
+      shift 2
+      ;;
+    --target-seconds)
+      [[ $# -ge 2 ]] || { echo "error: --target-seconds requires a value"; exit 1; }
+      TARGET_SEC="$2"
+      shift 2
+      ;;
+    --threads)
+      [[ $# -ge 2 ]] || { echo "error: --threads requires a value"; exit 1; }
+      THREADS="$2"
+      shift 2
+      ;;
+    --deals)
+      [[ $# -ge 2 ]] || { echo "error: --deals requires a value"; exit 1; }
+      FIXED_DEALS="$2"
+      shift 2
+      ;;
+    --probe-perf-deals)
+      [[ $# -ge 2 ]] || { echo "error: --probe-perf-deals requires a value"; exit 1; }
+      PROBE_PERF="$2"
+      shift 2
+      ;;
+    --probe-callgrind-deals)
+      [[ $# -ge 2 ]] || { echo "error: --probe-callgrind-deals requires a value"; exit 1; }
+      PROBE_CALLGRIND="$2"
+      shift 2
+      ;;
+    --no-build) DO_BUILD=false; shift ;;
+    --perf-record) PERF_RECORD=true; shift ;;
+    --perf-data)
+      [[ $# -ge 2 ]] || { echo "error: --perf-data requires a value"; exit 1; }
+      PERF_DATA="$2"
+      shift 2
+      ;;
+    --callgrind-out)
+      [[ $# -ge 2 ]] || { echo "error: --callgrind-out requires a value"; exit 1; }
+      CALLGRIND_OUT="$2"
+      shift 2
+      ;;
+    --call-graph)
+      [[ $# -ge 2 ]] || { echo "error: --call-graph requires a value"; exit 1; }
+      CALL_GRAPH="$2"
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+[[ ${#MODES[@]} -gt 0 ]] || {
+  echo "error: specify at least one --mode (perf | callgrind | plain)" >&2
+  usage >&2
+  exit 1
+}
+
+if "$DO_BUILD"; then
+  make -C "$ROOT" eval_match
+fi
+
+if [[ ! -x "$EXE" ]]; then
+  echo "error: missing executable ${BIN_REL}; run make eval_match from repo root." >&2
+  exit 1
+fi
+
+mkdir -p "${ROOT}/prof"
+
+elapsed_sec_plain() {
+  local deals="$1"
+  if [[ "${BASH_VERSINFO[0]}" -ge 5 ]]; then
+    local start="$EPOCHREALTIME"
+    "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
+      --deals "$deals" --seed "$SEED" --threads "$THREADS" \
+      >/dev/null 2>&1
+    local end="$EPOCHREALTIME"
+    awk -v a="$start" -v b="$end" 'BEGIN { printf "%f\n", (b > a ? b - a : 1e-9) }'
+  else
+    perl -e '
+      use Time::HiRes qw(time);
+      my ($exe, @args) = @ARGV;
+      open(my $bak, ">&", \*STDOUT) or die $!;
+      open(STDOUT, ">", "/dev/null") or die $!;
+      open(STDERR, ">", "/dev/null") or die $!;
+      my $t0 = time();
+      system $exe, @args and exit($? >> 8);
+      open(STDOUT, ">&", $bak);
+      printf "%f\n", time() - $t0;
+    ' "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
+      --deals "$deals" --seed "$SEED" --threads "$THREADS"
+  fi
+}
+
+# negligible vs plain; extrapolate perf-sized runs from plain probe time
+elapsed_sec_perf_stat() {
+  elapsed_sec_plain "$1"
+}
+
+elapsed_sec_callgrind() {
+  local deals="$1"
+  valgrind --tool=callgrind --instr-atstart=yes --quiet \
+    --callgrind-out-file=/dev/null -- \
+    "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
+      --deals "$deals" --seed "$SEED" --threads "$THREADS" \
+    >/dev/null 2>&1
+}
+
+scale_deals_from_probe() {
+  local probe="$1"
+  local t_probe="$2"
+  awk -v p="$probe" -v targ="$TARGET_SEC" -v t="$t_probe" '
+    BEGIN {
+      if (t <= 0) t = 1e-9;
+      x = int(p * targ / t + 0.5);
+      if (x < 1) x = 1;
+      print x;
+    }
+  ' </dev/null
+}
+
+resolve_deals() {
+  local kind="$1"
+  local probe="$2"
+
+  if [[ "$FIXED_DEALS" != "" ]]; then
+    echo "$FIXED_DEALS"
+    return
+  fi
+
+  if [[ "$probe" -lt 1 ]]; then
+    echo "error: probe deals must be >= 1 ($kind)" >&2
+    exit 1
+  fi
+
+  echo "Calib ($kind): probe deals=${probe}, seed=${SEED}, threads=${THREADS}" >&2
+  local t_probe
+  case "$kind" in
+    plain) t_probe="$(elapsed_sec_plain "$probe")" ;;
+    perf) t_probe="$(elapsed_sec_perf_stat "$probe")" ;;
+    callgrind)
+      command -v valgrind >/dev/null 2>&1 || {
+        echo "error: callgrind requested but valgrind not in PATH" >&2
+        exit 1
+      }
+      t_probe="$(elapsed_sec_callgrind "$probe")"
+      ;;
+  esac
+  echo "(probe wall ${t_probe}s) -> extrapolating to ~${TARGET_SEC}s target ..." >&2
+  scale_deals_from_probe "$probe" "$t_probe"
+}
+
+require_perf() {
+  command -v perf >/dev/null 2>&1 || {
+    echo "error: perf not in PATH" >&2
+    exit 1
+  }
+}
+
+run_mode_plain() {
+  local deals="$1"
+  echo "plain: deals=$deals  total_games=$((2 * deals))  seed=$SEED  threads=$THREADS" >&2
+  SECONDS=0
+  "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
+    --deals "$deals" --seed "$SEED" --threads "$THREADS"
+  echo "(plain wall-clock ~ ${SECONDS}s via bash \$SECONDS; see eval_match games/s)" >&2
+}
+
+run_mode_perf() {
+  local deals="$1"
+  echo "perf: deals=$deals  total_games=$((2 * deals))  seed=$SEED  threads=$THREADS" >&2
+  mkdir -p "$(dirname "${PERF_DATA}")"
+  require_perf
+
+  if "$PERF_RECORD"; then
+    echo "Recording to ${PERF_DATA} (--call-graph ${CALL_GRAPH})" >&2
+    perf record --output="${PERF_DATA}" -g --call-graph "${CALL_GRAPH}" -- \
+      "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
+      --deals "$deals" --seed "$SEED" --threads "$THREADS"
+    echo "perf report -i '${PERF_DATA}'" >&2
+  else
+    perf stat -r 1 -- \
+      "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
+      --deals "$deals" --seed "$SEED" --threads "$THREADS"
+  fi
+}
+
+run_mode_callgrind() {
+  local deals="$1"
+  echo "callgrind: deals=$deals  total_games=$((2 * deals))  seed=$SEED  threads=$THREADS" >&2
+  mkdir -p "$(dirname "${CALLGRIND_OUT}")"
+  command -v valgrind >/dev/null 2>&1 || {
+    echo "error: valgrind not in PATH" >&2
+    exit 1
+  }
+  echo "Writing ${CALLGRIND_OUT}" >&2
+  valgrind --tool=callgrind --instr-atstart=yes \
+    --callgrind-out-file="${CALLGRIND_OUT}" -- \
+    "$EXE" --p0 pimc --p0-param 20 --p1 pimc --p1-param 20 \
+    --deals "$deals" --seed "$SEED" --threads "$THREADS"
+  echo "KCachegrind / qcachegrind: ${CALLGRIND_OUT}" >&2
+}
+
+declare -A DID=()
+
+for m in "${MODES[@]}"; do
+  case "$m" in
+    perf | callgrind | plain)
+      ;;
+    *)
+      echo "error: unknown mode '${m}' (use perf | callgrind | plain)" >&2
+      exit 1
+      ;;
+  esac
+done
+
+for m in "${MODES[@]}"; do
+  [[ "${DID[$m]:-}" ]] && continue
+  DID["$m"]=1
+
+  deals=""
+  echo ""
+  echo "================ ${m} ================="
+  case "$m" in
+    plain)
+      deals="$(resolve_deals plain "${PROBE_PERF}")"
+      run_mode_plain "$deals"
+      ;;
+    perf)
+      require_perf
+      deals="$(resolve_deals perf "${PROBE_PERF}")"
+      run_mode_perf "$deals"
+      ;;
+    callgrind)
+      deals="$(resolve_deals callgrind "${PROBE_CALLGRIND}")"
+      run_mode_callgrind "$deals"
+      ;;
+  esac
+done
+

--- a/src/datagen/eval_match.cpp
+++ b/src/datagen/eval_match.cpp
@@ -60,6 +60,18 @@ static int run_paired_deal(unsigned int deal_seed,
   return a_wins;
 }
 
+// One full game per index; RNG state starts at seed+idx (distinct deals and lines).
+static int run_independent_game(unsigned int game_seed, PlayerFactory &factory_p0,
+                                PlayerFactory &factory_p1) {
+  std::mt19937 rng(game_seed);
+  auto p0 = factory_p0.create_player();
+  auto p1 = factory_p1.create_player();
+  GameSimulator sim(std::move(p0), std::move(p1), rng);
+  GameRecord rec = sim.run();
+  int winner = rec.game().get_winner();
+  return (winner == 0) ? 1 : 0;
+}
+
 // ============================================================================
 // CLI helpers
 // ============================================================================
@@ -72,7 +84,9 @@ static void print_usage(const char *prog) {
       << "  --p0-param <f>       Parameter for player A (default: 0.0)\n"
       << "  --p1 <name>          Player B type (required)\n"
       << "  --p1-param <f>       Parameter for player B (default: 0.0)\n"
-      << "  --deals <N>          Number of unique deals (total games = 2*N) (required)\n"
+      << "  --deals <N>          Paired evaluation: unique deals (total games = 2*N)\n"
+      << "  --games <N>          Independent full games per idx (RNG seed+N each)\n"
+      << "                         Mutually exclusive with --deals (one is required).\n"
       << "  --seed <S>           Base RNG seed (default: random)\n"
       << "  --threads <T>        Worker threads (default: hardware - 2)\n"
       << "\nAvailable players: random, greedy, greedy_random, greedy_random_pass, greedy_no_bomb,\n"
@@ -115,6 +129,7 @@ int main(int argc, char **argv) {
   std::string p0_name, p1_name;
   double p0_param = 0.0, p1_param = 0.0;
   int num_deals = 0;
+  int num_independent_games = 0;
   unsigned int seed = std::random_device{}();
   int num_threads = std::max(1u, std::thread::hardware_concurrency() - 2);
 
@@ -133,6 +148,8 @@ int main(int argc, char **argv) {
       p1_param = std::stod(argv[++i]);
     else if (arg == "--deals" && i + 1 < argc)
       num_deals = std::stoi(argv[++i]);
+    else if (arg == "--games" && i + 1 < argc)
+      num_independent_games = std::stoi(argv[++i]);
     else if (arg == "--seed" && i + 1 < argc)
       seed = static_cast<unsigned int>(std::stoul(argv[++i]));
     else if (arg == "--threads" && i + 1 < argc)
@@ -144,26 +161,49 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (p0_name.empty() || p1_name.empty() || num_deals <= 0) {
-    std::cerr << "Error: --p0, --p1, and --deals are required\n\n";
+  bool paired = num_deals > 0;
+  bool independent = num_independent_games > 0;
+  if (paired && independent) {
+    std::cerr << "Error: use only one of --deals or --games\n\n";
+    print_usage(argv[0]);
+    return 1;
+  }
+  if (p0_name.empty() || p1_name.empty() || (!paired && !independent)) {
+    std::cerr << "Error: --p0, --p1, and exactly one of --deals or --games are required\n\n";
+    print_usage(argv[0]);
+    return 1;
+  }
+  if (paired && num_deals <= 0) {
+    std::cerr << "Error: --deals must be positive\n\n";
+    print_usage(argv[0]);
+    return 1;
+  }
+  if (independent && num_independent_games <= 0) {
+    std::cerr << "Error: --games must be positive\n\n";
     print_usage(argv[0]);
     return 1;
   }
 
   std::string label0 = player_label(p0_name, p0_param);
   std::string label1 = player_label(p1_name, p1_param);
-  long total_games = 2L * num_deals;
+  long total_games = paired ? (2L * num_deals) : static_cast<long>(num_independent_games);
+  const int work_units = paired ? num_deals : num_independent_games;
 
-  std::cout << "\n=== Eval Match: " << label0 << " vs " << label1 << " ===\n"
-            << "Deals:   " << num_deals << "  |  Total games: " << total_games << "\n"
-            << "Seed:    " << seed << "\n"
+  std::cout << "\n=== Eval Match: " << label0 << " vs " << label1 << " ===\n";
+  if (paired) {
+    std::cout << "Mode: paired deals — deals " << num_deals << "  |  total games " << total_games
+              << "\n";
+  } else {
+    std::cout << "Mode: independent games — games " << num_independent_games << "\n";
+  }
+  std::cout << "Seed:    " << seed << "\n"
             << "Threads: " << num_threads << "\n\n";
 
   // Each thread gets factories seeded differently to avoid seed collisions
   // across threads (factories increment seeds per player created).
   // We give thread t an offset of t * 1000003 from the base seed.
-  std::atomic<int> next_deal{0};
-  std::atomic<long> a_wins_total{0};
+  std::atomic<int> next_unit{0};
+  std::atomic<long> aggregate_wins{0};
   std::atomic<long> deals_p0_sweep{0};
   std::atomic<long> deals_split{0};
   std::atomic<long> deals_p1_sweep{0};
@@ -173,32 +213,35 @@ int main(int argc, char **argv) {
   std::vector<std::thread> workers;
   workers.reserve(num_threads);
   for (int t = 0; t < num_threads; ++t) {
-    workers.emplace_back([&, t]() {
+    workers.emplace_back([&, paired, t]() {
       // Per-thread factories with distinct seeds so player RNGs don't overlap.
       unsigned int thread_seed = seed + static_cast<unsigned int>(t) * 1000003u;
       auto fa = make_player_factory(p0_name, p0_param, thread_seed);
       auto fb = make_player_factory(p1_name, p1_param, thread_seed + 500009u);
       if (!fa || !fb) return;
 
-      int deal_idx;
-      long local_wins = 0;
+      int idx;
+      long local_aggregate = 0;
       long local_p0_sweep = 0;
       long local_split = 0;
       long local_p1_sweep = 0;
-      while ((deal_idx = next_deal.fetch_add(1)) < num_deals) {
-        // Deal seed is deterministic from the global seed + deal index so
-        // that every thread arrives at the same card distribution for deal i.
-        unsigned int deal_seed = seed + static_cast<unsigned int>(deal_idx);
-        int r = run_paired_deal(deal_seed, *fa, *fb);
-        local_wins += r;
-        if (r == 2)
-          ++local_p0_sweep;
-        else if (r == 1)
-          ++local_split;
-        else
-          ++local_p1_sweep;
+
+      while ((idx = next_unit.fetch_add(1)) < work_units) {
+        unsigned int unit_seed = seed + static_cast<unsigned int>(idx);
+        if (paired) {
+          int r = run_paired_deal(unit_seed, *fa, *fb);
+          local_aggregate += r;
+          if (r == 2)
+            ++local_p0_sweep;
+          else if (r == 1)
+            ++local_split;
+          else
+            ++local_p1_sweep;
+        } else {
+          local_aggregate += run_independent_game(unit_seed, *fa, *fb);
+        }
       }
-      a_wins_total.fetch_add(local_wins);
+      aggregate_wins.fetch_add(local_aggregate);
       deals_p0_sweep.fetch_add(local_p0_sweep);
       deals_split.fetch_add(local_split);
       deals_p1_sweep.fetch_add(local_p1_sweep);
@@ -208,18 +251,29 @@ int main(int argc, char **argv) {
   // Progress monitor
   std::atomic<bool> progress_done{false};
   auto t_prog = std::chrono::steady_clock::now();
-  std::thread progress_thread([&]() {
+  std::thread progress_thread([&, paired]() {
     while (!progress_done.load()) {
-      int done = next_deal.load();
-      if (done > num_deals) done = num_deals;
+      int done = next_unit.load();
+      if (done > work_units) done = work_units;
       auto now = std::chrono::steady_clock::now();
       double elapsed = std::chrono::duration<double>(now - t_prog).count();
-      double rate = elapsed > 0 ? (2.0 * done) / elapsed : 0;
-      int pct = num_deals > 0 ? static_cast<int>(100.0 * done / num_deals) : 0;
-      std::fprintf(stderr, "\rDeals: %d/%d (%d%%)  |  %.0f games/s   ",
-                   done, num_deals, pct, rate);
+      double rate = 0;
+      int pct =
+          work_units > 0 ? static_cast<int>(100.0 * done / static_cast<double>(work_units)) : 0;
+      if (elapsed > 0) {
+        if (paired)
+          rate = (2.0 * done) / elapsed;
+        else
+          rate = done / elapsed;
+      }
+      if (paired)
+        std::fprintf(stderr, "\rDeals: %d/%d (%d%%)  |  %.0f games/s   ", done,
+                     work_units, pct, rate);
+      else
+        std::fprintf(stderr, "\rGames: %d/%d (%d%%)  |  %.0f games/s   ", done,
+                     work_units, pct, rate);
       std::fflush(stderr);
-      if (done >= num_deals) break;
+      if (done >= work_units) break;
       std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
   });
@@ -235,7 +289,7 @@ int main(int argc, char **argv) {
   long long elapsed_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(t_end - t_start).count();
 
-  long a_wins = a_wins_total.load();
+  long a_wins = aggregate_wins.load();
   double p_hat = static_cast<double>(a_wins) / static_cast<double>(total_games);
   WilsonCI ci = wilson_ci(p_hat, total_games);
   double games_per_sec = elapsed_ms > 0 ? 1000.0 * total_games / elapsed_ms : 0;
@@ -253,32 +307,35 @@ int main(int argc, char **argv) {
   else
     std::cout << "Result: no significant difference (CI includes 50%)\n";
 
-  long d0 = deals_p0_sweep.load();
-  long d1 = deals_split.load();
-  long d2 = deals_p1_sweep.load();
-  double inv_deals = num_deals > 0 ? 1.0 / static_cast<double>(num_deals) : 0.0;
+  if (paired) {
+    long d0 = deals_p0_sweep.load();
+    long d1 = deals_split.load();
+    long d2 = deals_p1_sweep.load();
+    double inv_deals =
+        num_deals > 0 ? 1.0 / static_cast<double>(num_deals) : 0.0;
 
-  std::cout << "Deals: P0_sweep=" << d0 << " split=" << d1 << " P1_sweep=" << d2
-            << " total=" << num_deals << "\n";
-  std::cout << "Deals: P0 sweep 2-0: " << d0 << " (" << std::fixed;
-  std::cout.precision(2);
-  std::cout << 100.0 * static_cast<double>(d0) * inv_deals << "%)  |  split 1-1: " << d1
-            << " (" << 100.0 * static_cast<double>(d1) * inv_deals << "%)  |  P1 sweep 0-2: "
-            << d2 << " (" << 100.0 * static_cast<double>(d2) * inv_deals << "%)\n";
+    std::cout << "Deals: P0_sweep=" << d0 << " split=" << d1 << " P1_sweep=" << d2
+              << " total=" << num_deals << "\n";
+    std::cout << "Deals: P0 sweep 2-0: " << d0 << " (" << std::fixed;
+    std::cout.precision(2);
+    std::cout << 100.0 * static_cast<double>(d0) * inv_deals << "%)  |  split 1-1: " << d1
+              << " (" << 100.0 * static_cast<double>(d1) * inv_deals << "%)  |  P1 sweep 0-2: "
+              << d2 << " (" << 100.0 * static_cast<double>(d2) * inv_deals << "%)\n";
 
-  long n_decisive = d0 + d2;
-  if (n_decisive > 0) {
-    double p_dec = static_cast<double>(d0) / static_cast<double>(n_decisive);
-    WilsonCI ci_dec = wilson_ci(p_dec, n_decisive);
-    std::cout << "Among decisive deals (non-split): P0 sweep " << d0 << " / " << n_decisive
-              << " (" << 100.0 * p_dec << "%)  95% Wilson CI: [" << 100.0 * ci_dec.lo << "%, "
-              << 100.0 * ci_dec.hi << "%]\n";
-    if (ci_dec.lo > 0.50)
-      std::cout << "Result (decisive): " << label0 << " sweeps more often (CI excludes 50%)\n";
-    else if (ci_dec.hi < 0.50)
-      std::cout << "Result (decisive): " << label1 << " sweeps more often (CI excludes 50%)\n";
-    else
-      std::cout << "Result (decisive): no significant difference (CI includes 50%)\n";
+    long n_decisive = d0 + d2;
+    if (n_decisive > 0) {
+      double p_dec = static_cast<double>(d0) / static_cast<double>(n_decisive);
+      WilsonCI ci_dec = wilson_ci(p_dec, n_decisive);
+      std::cout << "Among decisive deals (non-split): P0 sweep " << d0 << " / " << n_decisive
+                << " (" << 100.0 * p_dec << "%)  95% Wilson CI: [" << 100.0 * ci_dec.lo << "%, "
+                << 100.0 * ci_dec.hi << "%]\n";
+      if (ci_dec.lo > 0.50)
+        std::cout << "Result (decisive): " << label0 << " sweeps more often (CI excludes 50%)\n";
+      else if (ci_dec.hi < 0.50)
+        std::cout << "Result (decisive): " << label1 << " sweeps more often (CI excludes 50%)\n";
+      else
+        std::cout << "Result (decisive): no significant difference (CI includes 50%)\n";
+    }
   }
 
   std::cout << "Elapsed: " << format_elapsed(elapsed_ms)


### PR DESCRIPTION
## Summary
- Add `scripts/profile_pimc_selfplay.sh`: perf / callgrind / optional plain; fixed default seed; calibrates to target wall time; defaults to **independent** `--games` for richer positions, with `--paired-deals` for classical eval.
- Ignore `prof/` and `perf.data*` in `.gitignore`.
- `eval_match`: new `--games N` mode (mutually exclusive with `--deals`) for N independent games with `seed+idx` RNG per game.

## Note
Rust `target/` build artifacts from the diff tab were **not** committed (build output should stay local; add `target/` to `.gitignore` in a follow-up if you use cargo in-repo).

Made with [Cursor](https://cursor.com)