### PR TITLE
feat: NN training infrastructure — pool eval, C++ trick labels, streaming loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ TEST_CPP    := $(wildcard test/*.cpp)
 RESEARCH_BIN_NAMES := best_hand multi_comb play_probs count_turn_states
 RESEARCH_BINS      := $(addprefix $(BUILD_DIR)/research/,$(RESEARCH_BIN_NAMES))
 
-.PHONY: all clean dirs test_core coordinator generate_data generate_nn_data eval_match eval_nn_match eval_nn_vs_classic pass_greedy_datagen move_agreement benchmark tablebase_opp1_gen research help
+.PHONY: all clean dirs test_core coordinator generate_data generate_nn_data eval_match eval_nn_match eval_nn_vs_classic play_games pass_greedy_datagen move_agreement benchmark tablebase_opp1_gen research help
 
 all: help
 
@@ -37,6 +37,7 @@ help:
 	@echo "  make generate_nn_selfplay - NN self-play data gen (needs libarrow + LibTorch)"
 	@echo "  make eval_nn_match        - head-to-head NN model eval (needs LibTorch)"
 	@echo "  make eval_nn_vs_classic   - NN vs classic player eval (needs LibTorch)"
+	@echo "  make play_games           - play games + print per-turn decisions (needs LibTorch)"
 	@echo "Targets:"
 	@echo "  make test_core            - unit tests (no Arrow)"
 	@echo "  make benchmark            - perf benchmark binary (no Arrow)"
@@ -203,6 +204,23 @@ $(BIN_DIR)/eval_nn_match: $(EVALNNMATCH_OBJS)
 	@echo "✓ $(BIN_DIR)/eval_nn_match"
 
 eval_nn_match: dirs $(BIN_DIR)/eval_nn_match
+
+# ============================================================================
+# ============================================================================
+# bin/play_games — play games and print per-turn NN decisions (needs LibTorch)
+# ============================================================================
+
+$(BUILD_DIR)/src/datagen/play_games.o: src/datagen/play_games.cpp | dirs
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(INCLUDES) $(TORCH_INCLUDES) -c $< -o $@
+
+PLAYGAMES_OBJS := $(CORE_OBJS) \
+                  $(BUILD_DIR)/src/datagen/play_games.o
+
+$(BIN_DIR)/play_games: $(PLAYGAMES_OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS_TORCH)
+	@echo "✓ $(BIN_DIR)/play_games"
+
+play_games: dirs $(BIN_DIR)/play_games
 
 # ============================================================================
 # bin/eval_nn_vs_classic — NN model vs classic player evaluation (needs LibTorch)

--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,13 @@ TEST_CPP    := $(wildcard test/*.cpp)
 RESEARCH_BIN_NAMES := best_hand multi_comb play_probs count_turn_states
 RESEARCH_BINS      := $(addprefix $(BUILD_DIR)/research/,$(RESEARCH_BIN_NAMES))
 
-.PHONY: all clean dirs test_core coordinator generate_data generate_nn_data eval_match pass_greedy_datagen move_agreement benchmark tablebase_opp1_gen research help
+.PHONY: all clean dirs test_core coordinator generate_data generate_nn_data eval_match eval_nn_match pass_greedy_datagen move_agreement benchmark tablebase_opp1_gen research help
 
 all: help
 
 help:
 	@echo "  make generate_nn_selfplay - NN self-play data gen (needs libarrow + LibTorch)"
+	@echo "  make eval_nn_match        - head-to-head NN model eval (needs LibTorch)"
 	@echo "Targets:"
 	@echo "  make test_core            - unit tests (no Arrow)"
 	@echo "  make benchmark            - perf benchmark binary (no Arrow)"
@@ -184,6 +185,23 @@ $(BIN_DIR)/generate_nn_selfplay: $(GENNN_SELFPLAY_OBJS)
 	@echo "✓ $(BIN_DIR)/generate_nn_selfplay"
 
 generate_nn_selfplay: dirs $(BIN_DIR)/generate_nn_selfplay
+
+# ============================================================================
+# bin/eval_nn_match — head-to-head NN model evaluation (needs LibTorch)
+# ============================================================================
+
+$(BUILD_DIR)/src/datagen/eval_nn_match.o: src/datagen/eval_nn_match.cpp | dirs
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(INCLUDES) $(TORCH_INCLUDES) -c $< -o $@
+
+EVALNNMATCH_OBJS := $(CORE_OBJS) \
+                    $(BUILD_DIR)/src/simulation/nn_game_runner.o \
+                    $(BUILD_DIR)/src/datagen/eval_nn_match.o
+
+$(BIN_DIR)/eval_nn_match: $(EVALNNMATCH_OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS_TORCH)
+	@echo "✓ $(BIN_DIR)/eval_nn_match"
+
+eval_nn_match: dirs $(BIN_DIR)/eval_nn_match
 
 # ============================================================================
 # bin/eval_match — head-to-head evaluation (no Arrow)

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,14 @@ TEST_CPP    := $(wildcard test/*.cpp)
 RESEARCH_BIN_NAMES := best_hand multi_comb play_probs count_turn_states
 RESEARCH_BINS      := $(addprefix $(BUILD_DIR)/research/,$(RESEARCH_BIN_NAMES))
 
-.PHONY: all clean dirs test_core coordinator generate_data generate_nn_data eval_match eval_nn_match pass_greedy_datagen move_agreement benchmark tablebase_opp1_gen research help
+.PHONY: all clean dirs test_core coordinator generate_data generate_nn_data eval_match eval_nn_match eval_nn_vs_classic pass_greedy_datagen move_agreement benchmark tablebase_opp1_gen research help
 
 all: help
 
 help:
 	@echo "  make generate_nn_selfplay - NN self-play data gen (needs libarrow + LibTorch)"
 	@echo "  make eval_nn_match        - head-to-head NN model eval (needs LibTorch)"
+	@echo "  make eval_nn_vs_classic   - NN vs classic player eval (needs LibTorch)"
 	@echo "Targets:"
 	@echo "  make test_core            - unit tests (no Arrow)"
 	@echo "  make benchmark            - perf benchmark binary (no Arrow)"
@@ -202,6 +203,23 @@ $(BIN_DIR)/eval_nn_match: $(EVALNNMATCH_OBJS)
 	@echo "✓ $(BIN_DIR)/eval_nn_match"
 
 eval_nn_match: dirs $(BIN_DIR)/eval_nn_match
+
+# ============================================================================
+# bin/eval_nn_vs_classic — NN model vs classic player evaluation (needs LibTorch)
+# ============================================================================
+
+$(BUILD_DIR)/src/datagen/eval_nn_vs_classic.o: src/datagen/eval_nn_vs_classic.cpp | dirs
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(INCLUDES) $(TORCH_INCLUDES) -c $< -o $@
+
+EVALNNVSCLA_OBJS := $(CORE_OBJS) \
+                    $(BUILD_DIR)/src/simulation/game_simulator.o \
+                    $(BUILD_DIR)/src/datagen/eval_nn_vs_classic.o
+
+$(BIN_DIR)/eval_nn_vs_classic: $(EVALNNVSCLA_OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS_TORCH)
+	@echo "✓ $(BIN_DIR)/eval_nn_vs_classic"
+
+eval_nn_vs_classic: dirs $(BIN_DIR)/eval_nn_vs_classic
 
 # ============================================================================
 # bin/eval_match — head-to-head evaluation (no Arrow)

--- a/analysis/train_tree_greedy.py
+++ b/analysis/train_tree_greedy.py
@@ -305,7 +305,10 @@ def run_depth_sweep(
     depths: list[int],
     min_samples_leaf: int,
     kf,
-) -> tuple[list[dict], list[tuple[float, int, int, DecisionTreeRegressor]],]:
+) -> tuple[
+    list[dict],
+    list[tuple[float, int, int, DecisionTreeRegressor]],
+]:
     """Returns sweep_rows and (cv_brier, depth, min_samples_leaf, fitted_model)."""
     sweep_rows: list[dict] = []
     results: list[tuple[float, int, int, DecisionTreeRegressor]] = []

--- a/analysis/train_tree_greedy.py
+++ b/analysis/train_tree_greedy.py
@@ -305,10 +305,7 @@ def run_depth_sweep(
     depths: list[int],
     min_samples_leaf: int,
     kf,
-) -> tuple[
-    list[dict],
-    list[tuple[float, int, int, DecisionTreeRegressor]],
-]:
+) -> tuple[list[dict], list[tuple[float, int, int, DecisionTreeRegressor]],]:
     """Returns sweep_rows and (cv_brier, depth, min_samples_leaf, fitted_model)."""
     sweep_rows: list[dict] = []
     results: list[tuple[float, int, int, DecisionTreeRegressor]] = []

--- a/nn/dataset.py
+++ b/nn/dataset.py
@@ -292,11 +292,17 @@ class Big2SelfPlayDataset(Dataset):
         df = df.dropna(subset=["p_win_trick"]).reset_index(drop=True)
 
         if subsample_frac < 1.0:
-            df = df.sample(frac=subsample_frac, random_state=seed).reset_index(drop=True)
+            df = df.sample(frac=subsample_frac, random_state=seed).reset_index(
+                drop=True
+            )
 
         if new_format:
-            hand_counts = df[[f"hand_after_{r}" for r in range(13)]].to_numpy(dtype=np.int32)
-            opp_counts  = df[[f"opp_cnt_{r}"    for r in range(13)]].to_numpy(dtype=np.int32)
+            hand_counts = df[[f"hand_after_{r}" for r in range(13)]].to_numpy(
+                dtype=np.int32
+            )
+            opp_counts = df[[f"opp_cnt_{r}" for r in range(13)]].to_numpy(
+                dtype=np.int32
+            )
         else:
             hand_counts = decode_handbits_np(
                 df["hand_at1"].to_numpy(dtype=np.int32),
@@ -317,7 +323,9 @@ class Big2SelfPlayDataset(Dataset):
         self.opp_enc = torch.from_numpy(encode_upper_bound_np(opp_counts))
         self.move_enc = torch.from_numpy(encode_exact_np(move_counts))
 
-        self.hint = torch.tensor(df["hint"].to_numpy(dtype=np.float32), dtype=torch.float32)
+        self.hint = torch.tensor(
+            df["hint"].to_numpy(dtype=np.float32), dtype=torch.float32
+        )
         self.flag = torch.tensor(df["flag"].to_numpy(dtype=bool), dtype=torch.bool)
         self.pass_ = torch.tensor(df["pass_"].to_numpy(dtype=bool), dtype=torch.bool)
 
@@ -337,7 +345,9 @@ class Big2SelfPlayDataset(Dataset):
             df["winner"].to_numpy(dtype=np.int32)
             == df["current_player"].to_numpy(dtype=np.int32)
         ).astype(np.float32)
-        self.y_trick = torch.tensor(df["p_win_trick"].to_numpy(dtype=np.float32), dtype=torch.float32)
+        self.y_trick = torch.tensor(
+            df["p_win_trick"].to_numpy(dtype=np.float32), dtype=torch.float32
+        )
         self.y_win = torch.tensor(y_win, dtype=torch.float32)
 
     def __len__(self) -> int:
@@ -377,7 +387,7 @@ def _split_one(
     DatasetClass = Big2SelfPlayDataset if is_selfplay else Big2Dataset
     kwargs = {"subsample_frac": subsample_frac, "seed": seed} if is_selfplay else {}
     return (
-        DatasetClass(parquet_path, val_game_ids=val_ids, train=True,  **kwargs),
+        DatasetClass(parquet_path, val_game_ids=val_ids, train=True, **kwargs),
         DatasetClass(parquet_path, val_game_ids=val_ids, train=False, **kwargs),
     )
 

--- a/nn/dataset.py
+++ b/nn/dataset.py
@@ -256,19 +256,32 @@ def compute_trick_winners_selfplay(df: pd.DataFrame) -> pd.Series:
 class Big2SelfPlayDataset(Dataset):
     """Dataset for generate_nn_selfplay parquet output.
 
-    Columns: game_id, turn_idx, current_player, move_at0..12,
-             hand_at1..4, opp_at1..4, hint (float), flag (bool),
-             pass_ (bool), winner.
+    New format (hand_after_0..12 / opp_cnt_0..12 / trick_winner columns):
+      C++ pre-computed rank counts and trick labels — no Python processing.
+
+    Old format fallback (hand_at1..4 / opp_at1..4):
+      Decodes HandBits and computes trick labels in Python.
     """
 
     def __init__(
-        self, parquet_path: str, val_game_ids: Optional[set] = None, train: bool = True
+        self,
+        parquet_path: str,
+        val_game_ids: Optional[set] = None,
+        train: bool = True,
+        subsample_frac: float = 1.0,
+        seed: int = 0,
     ) -> None:
         df = pd.read_parquet(parquet_path)
         df = df.sort_values(["game_id", "turn_idx"]).reset_index(drop=True)
 
-        trick_labels = compute_trick_winners_selfplay(df)
-        df["p_win_trick"] = trick_labels
+        new_format = "hand_after_0" in df.columns
+
+        if new_format:
+            # C++ already computed trick_winner — use directly, no Python loop needed.
+            df["p_win_trick"] = df["trick_winner"].astype(float)
+        else:
+            trick_labels = compute_trick_winners_selfplay(df)
+            df["p_win_trick"] = trick_labels
 
         if val_game_ids is not None:
             if train:
@@ -278,37 +291,53 @@ class Big2SelfPlayDataset(Dataset):
 
         df = df.dropna(subset=["p_win_trick"]).reset_index(drop=True)
 
-        hand_counts = decode_handbits_np(
-            df["hand_at1"].to_numpy(dtype=np.int32),
-            df["hand_at2"].to_numpy(dtype=np.int32),
-            df["hand_at3"].to_numpy(dtype=np.int32),
-            df["hand_at4"].to_numpy(dtype=np.int32),
-        )
-        opp_counts = decode_handbits_np(
-            df["opp_at1"].to_numpy(dtype=np.int32),
-            df["opp_at2"].to_numpy(dtype=np.int32),
-            df["opp_at3"].to_numpy(dtype=np.int32),
-            df["opp_at4"].to_numpy(dtype=np.int32),
-        )
+        if subsample_frac < 1.0:
+            df = df.sample(frac=subsample_frac, random_state=seed).reset_index(drop=True)
+
+        if new_format:
+            hand_counts = df[[f"hand_after_{r}" for r in range(13)]].to_numpy(dtype=np.int32)
+            opp_counts  = df[[f"opp_cnt_{r}"    for r in range(13)]].to_numpy(dtype=np.int32)
+        else:
+            hand_counts = decode_handbits_np(
+                df["hand_at1"].to_numpy(dtype=np.int32),
+                df["hand_at2"].to_numpy(dtype=np.int32),
+                df["hand_at3"].to_numpy(dtype=np.int32),
+                df["hand_at4"].to_numpy(dtype=np.int32),
+            )
+            opp_counts = decode_handbits_np(
+                df["opp_at1"].to_numpy(dtype=np.int32),
+                df["opp_at2"].to_numpy(dtype=np.int32),
+                df["opp_at3"].to_numpy(dtype=np.int32),
+                df["opp_at4"].to_numpy(dtype=np.int32),
+            )
+
         move_counts = df[[f"move_at{r}" for r in range(13)]].to_numpy(dtype=np.int32)
 
         self.hand_enc = torch.from_numpy(encode_exact_np(hand_counts))
         self.opp_enc = torch.from_numpy(encode_upper_bound_np(opp_counts))
         self.move_enc = torch.from_numpy(encode_exact_np(move_counts))
 
-        self.hint = torch.tensor(
-            df["hint"].to_numpy(dtype=np.float32), dtype=torch.float32
-        )
+        self.hint = torch.tensor(df["hint"].to_numpy(dtype=np.float32), dtype=torch.float32)
         self.flag = torch.tensor(df["flag"].to_numpy(dtype=bool), dtype=torch.bool)
         self.pass_ = torch.tensor(df["pass_"].to_numpy(dtype=bool), dtype=torch.bool)
+
+        if "vi_forced" in df.columns:
+            vi_forced = df["vi_forced"].to_numpy(dtype=bool)
+        else:
+            vi_forced = np.zeros(len(df), dtype=bool)
+        self.vi_forced = torch.tensor(vi_forced, dtype=torch.bool)
+
+        if "vn_forced" in df.columns:
+            vn_forced = df["vn_forced"].to_numpy(dtype=bool)
+        else:
+            vn_forced = np.zeros(len(df), dtype=bool)
+        self.vn_forced = torch.tensor(vn_forced, dtype=torch.bool)
 
         y_win = (
             df["winner"].to_numpy(dtype=np.int32)
             == df["current_player"].to_numpy(dtype=np.int32)
         ).astype(np.float32)
-        self.y_trick = torch.tensor(
-            df["p_win_trick"].to_numpy(dtype=np.float32), dtype=torch.float32
-        )
+        self.y_trick = torch.tensor(df["p_win_trick"].to_numpy(dtype=np.float32), dtype=torch.float32)
         self.y_win = torch.tensor(y_win, dtype=torch.float32)
 
     def __len__(self) -> int:
@@ -322,15 +351,17 @@ class Big2SelfPlayDataset(Dataset):
             self.hint[idx],
             self.flag[idx],
             self.pass_[idx],
+            self.vi_forced[idx],
+            self.vn_forced[idx],
             self.y_trick[idx],
             self.y_win[idx],
         )
 
 
-def make_train_val_split(
-    parquet_path: str, val_frac: float = 0.1, seed: int = 0
-) -> tuple[Big2Dataset, Big2Dataset]:
-    """Return (train, val) datasets split by game ID, auto-detecting format."""
+def _split_one(
+    parquet_path: str, val_frac: float, seed: int, subsample_frac: float = 1.0
+) -> tuple[Dataset, Dataset]:
+    """Train/val split for a single parquet file."""
     import pyarrow.parquet as pq
 
     schema_names = set(pq.read_schema(parquet_path).names)
@@ -344,6 +375,36 @@ def make_train_val_split(
     val_ids = set(game_ids[:n_val].tolist())
 
     DatasetClass = Big2SelfPlayDataset if is_selfplay else Big2Dataset
-    train_ds = DatasetClass(parquet_path, val_game_ids=val_ids, train=True)
-    val_ds = DatasetClass(parquet_path, val_game_ids=val_ids, train=False)
+    kwargs = {"subsample_frac": subsample_frac, "seed": seed} if is_selfplay else {}
+    return (
+        DatasetClass(parquet_path, val_game_ids=val_ids, train=True,  **kwargs),
+        DatasetClass(parquet_path, val_game_ids=val_ids, train=False, **kwargs),
+    )
+
+
+def make_train_val_split(
+    parquet_paths: "str | list[str]",
+    val_frac: float = 0.1,
+    seed: int = 0,
+    mix_decay: float = 1.0,
+) -> "tuple[Dataset, Dataset]":
+    """Return (train, val) datasets split by game ID, auto-detecting format.
+
+    parquet_paths may be a single path or a list. When mix_decay < 1, each
+    subsequent file is subsampled by mix_decay^i (file 0 = full, file 1 = mix_decay,
+    file 2 = mix_decay^2, etc.) to blend older-generation data.
+    """
+    from torch.utils.data import ConcatDataset
+
+    if isinstance(parquet_paths, str):
+        parquet_paths = [parquet_paths]
+
+    fracs = [mix_decay**i for i in range(len(parquet_paths))]
+    splits = [
+        _split_one(p, val_frac, seed + i, subsample_frac=fracs[i])
+        for i, p in enumerate(parquet_paths)
+    ]
+    train_parts, val_parts = zip(*splits)
+    train_ds = train_parts[0] if len(train_parts) == 1 else ConcatDataset(train_parts)
+    val_ds = val_parts[0] if len(val_parts) == 1 else ConcatDataset(val_parts)
     return train_ds, val_ds

--- a/nn/train.py
+++ b/nn/train.py
@@ -35,13 +35,17 @@ def compute_loss(
     p_trick: torch.Tensor,
     y_trick: torch.Tensor,
     y_win: torch.Tensor,
+    vi_forced: torch.Tensor,
+    vn_forced: torch.Tensor,
 ) -> tuple[torch.Tensor, dict]:
     """Three-headed BCE loss with per-head masking.
 
     p_trick is trained on all normal moves (pass/flag rows contribute zero
     gradient via the post-processing in model.forward).
     v_init is trained only on rows where the player won the trick (y_trick=1).
+      When vi_forced=True, the target is overridden to 1.0 (tablebase-proven win).
     v_no_init is trained only on rows where the player lost the trick (y_trick=0).
+      When vn_forced=True, the target is overridden to 0.0 (can't win w/o initiative).
     """
     eps = 1e-7
     p_trick_c = p_trick.clamp(eps, 1 - eps)
@@ -54,14 +58,20 @@ def compute_loss(
     no_trick_mask = ~trick_mask
 
     if trick_mask.any():
-        loss_vi = F.binary_cross_entropy(v_init_c[trick_mask], y_win[trick_mask])
+        vi_target = y_win[trick_mask]
+        vi_f = vi_forced[trick_mask]
+        if vi_f.any():
+            vi_target = torch.where(vi_f, torch.ones_like(vi_target), vi_target)
+        loss_vi = F.binary_cross_entropy(v_init_c[trick_mask], vi_target)
     else:
         loss_vi = torch.tensor(0.0, device=p_trick.device)
 
     if no_trick_mask.any():
-        loss_vn = F.binary_cross_entropy(
-            v_no_init_c[no_trick_mask], y_win[no_trick_mask]
-        )
+        vn_target = y_win[no_trick_mask]
+        vn_f = vn_forced[no_trick_mask]
+        if vn_f.any():
+            vn_target = torch.where(vn_f, torch.zeros_like(vn_target), vn_target)
+        loss_vn = F.binary_cross_entropy(v_no_init_c[no_trick_mask], vn_target)
     else:
         loss_vn = torch.tensor(0.0, device=p_trick.device)
 
@@ -80,12 +90,15 @@ def compute_loss(
 
 
 def train(
-    parquet_path: str,
+    parquet_paths: list[str],
     out_path: str,
-    epochs: int = 20,
+    epochs: int = 10,
     batch_size: int = 2048,
     val_frac: float = 0.1,
     lr: float = 3e-4,
+    lr_warmup: float = 0.05,
+    final_div_factor: float = 100.0,
+    mix_decay: float = 1.0,
     weight_decay: float = 1e-5,
     grad_clip: float = 0.5,
     num_workers: int = 8,
@@ -100,9 +113,12 @@ def train(
         device = torch.device(device_str)
     print(f"Device: {device}")
 
-    print("Loading dataset...")
+    if len(parquet_paths) > 1:
+        print(f"Loading dataset ({len(parquet_paths)} files)...")
+    else:
+        print("Loading dataset...")
     t0 = time.time()
-    train_ds, val_ds = make_train_val_split(parquet_path, val_frac=val_frac, seed=seed)
+    train_ds, val_ds = make_train_val_split(parquet_paths, val_frac=val_frac, seed=seed, mix_decay=mix_decay)
     print(f"  train={len(train_ds):,}  val={len(val_ds):,}  ({time.time()-t0:.1f}s)")
 
     train_loader = DataLoader(
@@ -143,10 +159,10 @@ def train(
         optimizer,
         max_lr=lr,
         total_steps=total_steps,
-        pct_start=0.1,
+        pct_start=lr_warmup,
         anneal_strategy="cos",
         div_factor=10.0,
-        final_div_factor=100.0,
+        final_div_factor=final_div_factor,
     )
 
     out_path = Path(out_path)
@@ -162,13 +178,13 @@ def train(
         tr_p = tr_vi = tr_vn = 0.0
         n_batches = 0
         for batch_idx, batch in enumerate(train_loader):
-            hand, opp, move, hint, flag, pass_, y_trick, y_win = (
+            hand, opp, move, hint, flag, pass_, vi_forced, vn_forced, y_trick, y_win = (
                 t.to(device) for t in batch
             )
 
             optimizer.zero_grad()
             v_init, v_no_init, p_trick = model(hand, opp, move, hint, flag, pass_)
-            loss, metrics = compute_loss(v_init, v_no_init, p_trick, y_trick, y_win)
+            loss, metrics = compute_loss(v_init, v_no_init, p_trick, y_trick, y_win, vi_forced, vn_forced)
             loss.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
             optimizer.step()
@@ -196,11 +212,11 @@ def train(
         n_val = 0
         with torch.no_grad():
             for batch in val_loader:
-                hand, opp, move, hint, flag, pass_, y_trick, y_win = (
+                hand, opp, move, hint, flag, pass_, vi_forced, vn_forced, y_trick, y_win = (
                     t.to(device) for t in batch
                 )
                 v_init, v_no_init, p_trick = model(hand, opp, move, hint, flag, pass_)
-                loss, metrics = compute_loss(v_init, v_no_init, p_trick, y_trick, y_win)
+                loss, metrics = compute_loss(v_init, v_no_init, p_trick, y_trick, y_win, vi_forced, vn_forced)
                 bs = len(y_trick)
                 val_loss += loss.item() * bs
                 val_p += metrics["loss_p_trick"] * bs
@@ -245,14 +261,22 @@ def train(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train Big2Net")
-    parser.add_argument("parquet", help="Path to *_turn.parquet from dnn datagen")
+    parser.add_argument(
+        "parquet", nargs="+", help="Parquet file(s) from dnn datagen (mixed if multiple)"
+    )
     parser.add_argument(
         "--out", default="models/model.pt", help="Output TorchScript model path"
     )
-    parser.add_argument("--epochs", type=int, default=20)
+    parser.add_argument("--epochs", type=int, default=10)
     parser.add_argument("--batch", type=int, default=2048)
     parser.add_argument("--val-frac", type=float, default=0.1)
     parser.add_argument("--lr", type=float, default=3e-4)
+    parser.add_argument("--lr-warmup", type=float, default=0.05,
+                        help="Fraction of steps for LR warmup (OneCycleLR pct_start)")
+    parser.add_argument("--final-div-factor", type=float, default=100.0,
+                        help="OneCycleLR final_div_factor; final LR = max_lr/(div_factor*this)")
+    parser.add_argument("--mix-decay", type=float, default=1.0,
+                        help="Subsample fraction per older generation file (0.5 = halve each step back)")
     parser.add_argument("--weight-decay", type=float, default=1e-5)
     parser.add_argument("--grad-clip", type=float, default=0.5)
     parser.add_argument("--workers", type=int, default=8)
@@ -261,12 +285,15 @@ def main() -> None:
     args = parser.parse_args()
 
     train(
-        parquet_path=args.parquet,
+        parquet_paths=args.parquet,
         out_path=args.out,
         epochs=args.epochs,
         batch_size=args.batch,
         val_frac=args.val_frac,
         lr=args.lr,
+        lr_warmup=args.lr_warmup,
+        final_div_factor=args.final_div_factor,
+        mix_decay=args.mix_decay,
         weight_decay=args.weight_decay,
         grad_clip=args.grad_clip,
         num_workers=args.workers,

--- a/nn/train.py
+++ b/nn/train.py
@@ -159,6 +159,7 @@ def train(
         # --- Train ---
         model.train()
         train_loss = 0.0
+        tr_p = tr_vi = tr_vn = 0.0
         n_batches = 0
         for batch_idx, batch in enumerate(train_loader):
             hand, opp, move, hint, flag, pass_, y_trick, y_win = (
@@ -167,13 +168,16 @@ def train(
 
             optimizer.zero_grad()
             v_init, v_no_init, p_trick = model(hand, opp, move, hint, flag, pass_)
-            loss, _ = compute_loss(v_init, v_no_init, p_trick, y_trick, y_win)
+            loss, metrics = compute_loss(v_init, v_no_init, p_trick, y_trick, y_win)
             loss.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
             optimizer.step()
             scheduler.step()
 
             train_loss += loss.item()
+            tr_p += metrics["loss_p_trick"]
+            tr_vi += metrics["loss_v_init"]
+            tr_vn += metrics["loss_v_no_init"]
             n_batches += 1
 
             if (batch_idx + 1) % log_every == 0:
@@ -187,6 +191,7 @@ def train(
         # --- Validate ---
         model.eval()
         val_loss = 0.0
+        val_p = val_vi = val_vn = 0.0
         val_p_brier = 0.0
         n_val = 0
         with torch.no_grad():
@@ -198,17 +203,27 @@ def train(
                 loss, metrics = compute_loss(v_init, v_no_init, p_trick, y_trick, y_win)
                 bs = len(y_trick)
                 val_loss += loss.item() * bs
+                val_p += metrics["loss_p_trick"] * bs
+                val_vi += metrics["loss_v_init"] * bs
+                val_vn += metrics["loss_v_no_init"] * bs
                 val_p_brier += ((p_trick - y_trick) ** 2).sum().item()
                 n_val += bs
 
         val_loss /= n_val
+        val_p /= n_val
+        val_vi /= n_val
+        val_vn /= n_val
         val_p_brier /= n_val
         train_avg = train_loss / n_batches
+        tr_p /= n_batches
+        tr_vi /= n_batches
+        tr_vn /= n_batches
 
         print(
             f"Epoch {epoch}/{epochs}  "
-            f"train={train_avg:.4f}  val={val_loss:.4f}  "
-            f"p_trick_brier={val_p_brier:.4f}"
+            f"train={train_avg:.4f} [p={tr_p:.3f} vi={tr_vi:.3f} vn={tr_vn:.3f}]  "
+            f"val={val_loss:.4f} [p={val_p:.3f} vi={val_vi:.3f} vn={val_vn:.3f}]  "
+            f"brier={val_p_brier:.4f}"
         )
 
         if val_loss < best_val_loss:

--- a/nn/train.py
+++ b/nn/train.py
@@ -118,7 +118,9 @@ def train(
     else:
         print("Loading dataset...")
     t0 = time.time()
-    train_ds, val_ds = make_train_val_split(parquet_paths, val_frac=val_frac, seed=seed, mix_decay=mix_decay)
+    train_ds, val_ds = make_train_val_split(
+        parquet_paths, val_frac=val_frac, seed=seed, mix_decay=mix_decay
+    )
     print(f"  train={len(train_ds):,}  val={len(val_ds):,}  ({time.time()-t0:.1f}s)")
 
     train_loader = DataLoader(
@@ -184,7 +186,9 @@ def train(
 
             optimizer.zero_grad()
             v_init, v_no_init, p_trick = model(hand, opp, move, hint, flag, pass_)
-            loss, metrics = compute_loss(v_init, v_no_init, p_trick, y_trick, y_win, vi_forced, vn_forced)
+            loss, metrics = compute_loss(
+                v_init, v_no_init, p_trick, y_trick, y_win, vi_forced, vn_forced
+            )
             loss.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
             optimizer.step()
@@ -212,11 +216,22 @@ def train(
         n_val = 0
         with torch.no_grad():
             for batch in val_loader:
-                hand, opp, move, hint, flag, pass_, vi_forced, vn_forced, y_trick, y_win = (
-                    t.to(device) for t in batch
-                )
+                (
+                    hand,
+                    opp,
+                    move,
+                    hint,
+                    flag,
+                    pass_,
+                    vi_forced,
+                    vn_forced,
+                    y_trick,
+                    y_win,
+                ) = (t.to(device) for t in batch)
                 v_init, v_no_init, p_trick = model(hand, opp, move, hint, flag, pass_)
-                loss, metrics = compute_loss(v_init, v_no_init, p_trick, y_trick, y_win, vi_forced, vn_forced)
+                loss, metrics = compute_loss(
+                    v_init, v_no_init, p_trick, y_trick, y_win, vi_forced, vn_forced
+                )
                 bs = len(y_trick)
                 val_loss += loss.item() * bs
                 val_p += metrics["loss_p_trick"] * bs
@@ -262,7 +277,9 @@ def train(
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train Big2Net")
     parser.add_argument(
-        "parquet", nargs="+", help="Parquet file(s) from dnn datagen (mixed if multiple)"
+        "parquet",
+        nargs="+",
+        help="Parquet file(s) from dnn datagen (mixed if multiple)",
     )
     parser.add_argument(
         "--out", default="models/model.pt", help="Output TorchScript model path"
@@ -271,12 +288,24 @@ def main() -> None:
     parser.add_argument("--batch", type=int, default=2048)
     parser.add_argument("--val-frac", type=float, default=0.1)
     parser.add_argument("--lr", type=float, default=3e-4)
-    parser.add_argument("--lr-warmup", type=float, default=0.05,
-                        help="Fraction of steps for LR warmup (OneCycleLR pct_start)")
-    parser.add_argument("--final-div-factor", type=float, default=100.0,
-                        help="OneCycleLR final_div_factor; final LR = max_lr/(div_factor*this)")
-    parser.add_argument("--mix-decay", type=float, default=1.0,
-                        help="Subsample fraction per older generation file (0.5 = halve each step back)")
+    parser.add_argument(
+        "--lr-warmup",
+        type=float,
+        default=0.05,
+        help="Fraction of steps for LR warmup (OneCycleLR pct_start)",
+    )
+    parser.add_argument(
+        "--final-div-factor",
+        type=float,
+        default=100.0,
+        help="OneCycleLR final_div_factor; final LR = max_lr/(div_factor*this)",
+    )
+    parser.add_argument(
+        "--mix-decay",
+        type=float,
+        default=1.0,
+        help="Subsample fraction per older generation file (0.5 = halve each step back)",
+    )
     parser.add_argument("--weight-decay", type=float, default=1e-5)
     parser.add_argument("--grad-clip", type=float, default=0.5)
     parser.add_argument("--workers", type=int, default=8)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,8 @@ analysis = [
 
 [tool.uv]
 package = false
+
+[dependency-groups]
+dev = [
+    "black==23.3.0",
+]

--- a/scripts/analyze_ptrick_loss.py
+++ b/scripts/analyze_ptrick_loss.py
@@ -53,8 +53,9 @@ def combo_label(move_counts: np.ndarray) -> str:
 
 def run_analysis(parquet_path: str, model_path: str, device_str: str = "auto"):
     device = torch.device(
-        "cuda" if (device_str == "auto" and torch.cuda.is_available()) else
-        ("cpu" if device_str == "cpu" else device_str)
+        "cuda"
+        if (device_str == "auto" and torch.cuda.is_available())
+        else ("cpu" if device_str == "cpu" else device_str)
     )
     print(f"Device: {device}")
 
@@ -64,16 +65,16 @@ def run_analysis(parquet_path: str, model_path: str, device_str: str = "auto"):
 
     # Encode features
     hand_counts = df[[f"hand_after_{r}" for r in range(13)]].to_numpy(dtype=np.int32)
-    opp_counts  = df[[f"opp_cnt_{r}"    for r in range(13)]].to_numpy(dtype=np.int32)
-    move_counts = df[[f"move_at{r}"     for r in range(13)]].to_numpy(dtype=np.int32)
+    opp_counts = df[[f"opp_cnt_{r}" for r in range(13)]].to_numpy(dtype=np.int32)
+    move_counts = df[[f"move_at{r}" for r in range(13)]].to_numpy(dtype=np.int32)
 
     hand_enc = torch.from_numpy(encode_exact_np(hand_counts)).float()
-    opp_enc  = torch.from_numpy(encode_upper_bound_np(opp_counts)).float()
+    opp_enc = torch.from_numpy(encode_upper_bound_np(opp_counts)).float()
     move_enc = torch.from_numpy(encode_exact_np(move_counts)).float()
-    hint     = torch.tensor(df["hint"].to_numpy(dtype=np.float32))
-    flag     = torch.tensor(df["flag"].to_numpy(dtype=bool))
-    pass_    = torch.tensor(df["pass_"].to_numpy(dtype=bool))
-    y_trick  = torch.tensor(df["trick_winner"].to_numpy(dtype=np.float32))
+    hint = torch.tensor(df["hint"].to_numpy(dtype=np.float32))
+    flag = torch.tensor(df["flag"].to_numpy(dtype=bool))
+    pass_ = torch.tensor(df["pass_"].to_numpy(dtype=bool))
+    y_trick = torch.tensor(df["trick_winner"].to_numpy(dtype=np.float32))
 
     print(f"Loading model {model_path}...")
     model = torch.jit.load(model_path)
@@ -88,8 +89,12 @@ def run_analysis(parquet_path: str, model_path: str, device_str: str = "auto"):
         for i in range(0, n, BATCH):
             sl = slice(i, i + BATCH)
             out = model.forward(
-                hand_enc[sl].to(device), opp_enc[sl].to(device), move_enc[sl].to(device),
-                hint[sl].to(device), flag[sl].to(device), pass_[sl].to(device)
+                hand_enc[sl].to(device),
+                opp_enc[sl].to(device),
+                move_enc[sl].to(device),
+                hint[sl].to(device),
+                flag[sl].to(device),
+                pass_[sl].to(device),
             )
             pt = out[2].cpu()  # p_trick output
             all_pt.append(pt)
@@ -105,13 +110,38 @@ def run_analysis(parquet_path: str, model_path: str, device_str: str = "auto"):
 
     y = y_trick.numpy()
 
-    print(f"\n{'Combo':<12} {'N':>8}  {'y=1%':>6}  {'BCE':>6}  {'pred_pt':>8}  {'brier':>7}")
+    print(
+        f"\n{'Combo':<12} {'N':>8}  {'y=1%':>6}  {'BCE':>6}  {'pred_pt':>8}  {'brier':>7}"
+    )
     print("-" * 60)
 
-    combo_order = ["single","pair","triple","full_house","bomb",
-                   "str5","str6","str7","str8","str9","str10","str11","str12","str13",
-                   "dstr2","dstr3","dstr4","dstr5","dstr6","dstr7","dstr8",
-                   "tstr2","tstr3","tstr4","tstr5"]
+    combo_order = [
+        "single",
+        "pair",
+        "triple",
+        "full_house",
+        "bomb",
+        "str5",
+        "str6",
+        "str7",
+        "str8",
+        "str9",
+        "str10",
+        "str11",
+        "str12",
+        "str13",
+        "dstr2",
+        "dstr3",
+        "dstr4",
+        "dstr5",
+        "dstr6",
+        "dstr7",
+        "dstr8",
+        "tstr2",
+        "tstr3",
+        "tstr4",
+        "tstr5",
+    ]
 
     seen = set()
     rows = []
@@ -121,26 +151,31 @@ def run_analysis(parquet_path: str, model_path: str, device_str: str = "auto"):
             continue
         seen.add(combo)
         pt_c = np.clip(pt_all[mask], 1e-7, 1 - 1e-7)
-        y_c  = y[mask]
-        bce  = -(y_c * np.log(pt_c) + (1 - y_c) * np.log(1 - pt_c)).mean()
+        y_c = y[mask]
+        bce = -(y_c * np.log(pt_c) + (1 - y_c) * np.log(1 - pt_c)).mean()
         brier = ((pt_c - y_c) ** 2).mean()
         y1_pct = y_c.mean() * 100
         pt_mean = pt_c.mean()
         rows.append((combo, mask.sum(), y1_pct, bce, pt_mean, brier))
-        print(f"{combo:<12} {mask.sum():>8,}  {y1_pct:>5.1f}%  {bce:>6.4f}  {pt_mean:>8.4f}  {brier:>7.4f}")
+        print(
+            f"{combo:<12} {mask.sum():>8,}  {y1_pct:>5.1f}%  {bce:>6.4f}  {pt_mean:>8.4f}  {brier:>7.4f}"
+        )
 
     # Overall (excluding pass)
     mask = active
     pt_c = np.clip(pt_all[mask], 1e-7, 1 - 1e-7)
-    y_c  = y[mask]
-    bce  = -(y_c * np.log(pt_c) + (1 - y_c) * np.log(1 - pt_c)).mean()
+    y_c = y[mask]
+    bce = -(y_c * np.log(pt_c) + (1 - y_c) * np.log(1 - pt_c)).mean()
     brier = ((pt_c - y_c) ** 2).mean()
     print("-" * 60)
-    print(f"{'ALL':<12} {mask.sum():>8,}  {y_c.mean()*100:>5.1f}%  {bce:>6.4f}  {pt_c.mean():>8.4f}  {brier:>7.4f}")
+    print(
+        f"{'ALL':<12} {mask.sum():>8,}  {y_c.mean()*100:>5.1f}%  {bce:>6.4f}  {pt_c.mean():>8.4f}  {brier:>7.4f}"
+    )
 
 
 if __name__ == "__main__":
     import argparse
+
     p = argparse.ArgumentParser()
     p.add_argument("parquet")
     p.add_argument("--model", default=None)

--- a/scripts/analyze_ptrick_loss.py
+++ b/scripts/analyze_ptrick_loss.py
@@ -1,0 +1,155 @@
+"""Break down p_trick BCE loss by move combination type across a parquet file."""
+
+import sys
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn.functional as F
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from nn.dataset import encode_exact_np, encode_upper_bound_np
+
+ENCODING_DIM = 48
+
+
+def combo_label(move_counts: np.ndarray) -> str:
+    """Classify a move from its rank-count array (shape 13)."""
+    total = move_counts.sum()
+    if total == 0:
+        return "pass"
+    if total == 1:
+        return "single"
+    if total == 2:
+        return "pair"
+    if total == 3:
+        if move_counts.max() == 3:
+            return "triple"
+        return "straight3?"
+    if total == 4:
+        if move_counts.max() == 4:
+            return "bomb"
+        return "other4"
+    if total == 5:
+        nonzero = (move_counts > 0).sum()
+        if nonzero == 2 and move_counts.max() == 3:
+            return "full_house"
+        if nonzero == 5:
+            return "str5"
+        return "other5"
+    if total <= 13:
+        # straight or double/triple straight
+        nonzero = (move_counts > 0).sum()
+        maxcount = move_counts.max()
+        if maxcount == 1:
+            return f"str{total}"
+        if maxcount == 2:
+            return f"dstr{total//2}"
+        if maxcount == 3:
+            return f"tstr{total//3}"
+        return f"other{total}"
+    return f"other{total}"
+
+
+def run_analysis(parquet_path: str, model_path: str, device_str: str = "auto"):
+    device = torch.device(
+        "cuda" if (device_str == "auto" and torch.cuda.is_available()) else
+        ("cpu" if device_str == "cpu" else device_str)
+    )
+    print(f"Device: {device}")
+
+    print(f"Loading {parquet_path}...")
+    df = pd.read_parquet(parquet_path)
+    print(f"  {len(df):,} rows")
+
+    # Encode features
+    hand_counts = df[[f"hand_after_{r}" for r in range(13)]].to_numpy(dtype=np.int32)
+    opp_counts  = df[[f"opp_cnt_{r}"    for r in range(13)]].to_numpy(dtype=np.int32)
+    move_counts = df[[f"move_at{r}"     for r in range(13)]].to_numpy(dtype=np.int32)
+
+    hand_enc = torch.from_numpy(encode_exact_np(hand_counts)).float()
+    opp_enc  = torch.from_numpy(encode_upper_bound_np(opp_counts)).float()
+    move_enc = torch.from_numpy(encode_exact_np(move_counts)).float()
+    hint     = torch.tensor(df["hint"].to_numpy(dtype=np.float32))
+    flag     = torch.tensor(df["flag"].to_numpy(dtype=bool))
+    pass_    = torch.tensor(df["pass_"].to_numpy(dtype=bool))
+    y_trick  = torch.tensor(df["trick_winner"].to_numpy(dtype=np.float32))
+
+    print(f"Loading model {model_path}...")
+    model = torch.jit.load(model_path)
+    model.eval()
+    model.to(device)
+
+    # Run inference in batches
+    BATCH = 8192
+    all_pt = []
+    n = len(df)
+    with torch.no_grad():
+        for i in range(0, n, BATCH):
+            sl = slice(i, i + BATCH)
+            out = model.forward(
+                hand_enc[sl].to(device), opp_enc[sl].to(device), move_enc[sl].to(device),
+                hint[sl].to(device), flag[sl].to(device), pass_[sl].to(device)
+            )
+            pt = out[2].cpu()  # p_trick output
+            all_pt.append(pt)
+    pt_all = torch.cat(all_pt).numpy()
+
+    # Classify each move
+    labels = np.array([combo_label(move_counts[i]) for i in range(n)])
+
+    # Exclude pass and flag rows from analysis (they contribute no gradient)
+    pass_mask = df["pass_"].to_numpy(dtype=bool)
+    flag_mask = df["flag"].to_numpy(dtype=bool)
+    active = ~pass_mask  # include flag (it's a real move) but exclude pass
+
+    y = y_trick.numpy()
+
+    print(f"\n{'Combo':<12} {'N':>8}  {'y=1%':>6}  {'BCE':>6}  {'pred_pt':>8}  {'brier':>7}")
+    print("-" * 60)
+
+    combo_order = ["single","pair","triple","full_house","bomb",
+                   "str5","str6","str7","str8","str9","str10","str11","str12","str13",
+                   "dstr2","dstr3","dstr4","dstr5","dstr6","dstr7","dstr8",
+                   "tstr2","tstr3","tstr4","tstr5"]
+
+    seen = set()
+    rows = []
+    for combo in combo_order + sorted(set(labels) - set(combo_order)):
+        mask = (labels == combo) & active
+        if mask.sum() == 0:
+            continue
+        seen.add(combo)
+        pt_c = np.clip(pt_all[mask], 1e-7, 1 - 1e-7)
+        y_c  = y[mask]
+        bce  = -(y_c * np.log(pt_c) + (1 - y_c) * np.log(1 - pt_c)).mean()
+        brier = ((pt_c - y_c) ** 2).mean()
+        y1_pct = y_c.mean() * 100
+        pt_mean = pt_c.mean()
+        rows.append((combo, mask.sum(), y1_pct, bce, pt_mean, brier))
+        print(f"{combo:<12} {mask.sum():>8,}  {y1_pct:>5.1f}%  {bce:>6.4f}  {pt_mean:>8.4f}  {brier:>7.4f}")
+
+    # Overall (excluding pass)
+    mask = active
+    pt_c = np.clip(pt_all[mask], 1e-7, 1 - 1e-7)
+    y_c  = y[mask]
+    bce  = -(y_c * np.log(pt_c) + (1 - y_c) * np.log(1 - pt_c)).mean()
+    brier = ((pt_c - y_c) ** 2).mean()
+    print("-" * 60)
+    print(f"{'ALL':<12} {mask.sum():>8,}  {y_c.mean()*100:>5.1f}%  {bce:>6.4f}  {pt_c.mean():>8.4f}  {brier:>7.4f}")
+
+
+if __name__ == "__main__":
+    import argparse
+    p = argparse.ArgumentParser()
+    p.add_argument("parquet")
+    p.add_argument("--model", default=None)
+    p.add_argument("--device", default="auto")
+    args = p.parse_args()
+
+    if args.model is None:
+        # infer model from parquet name: data/genN.parquet -> models/genN.pt
+        stem = Path(args.parquet).stem  # e.g. "gen6"
+        args.model = f"models/{stem}.pt"
+
+    run_analysis(args.parquet, args.model, args.device)

--- a/scripts/run_training_loop.sh
+++ b/scripts/run_training_loop.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# Self-play training loop: datagen → train (1 epoch) → eval → sample games → log.
+#
+# Usage:
+#   scripts/run_training_loop.sh [options]
+#
+# Options (all have defaults):
+#   --start N        first generation to produce     (default: auto = max existing gen + 1)
+#   --end N          last  generation to produce     (default: start)
+#   --games N        self-play games per gen         (default: 200000)
+#   --lr-init F      starting learning rate (gen 1)  (default: 0.001)
+#   --lr-decay F     LR multiplier per generation    (default: 0.9)
+#   --lr-min F       minimum LR floor                (default: 0.0001)
+#   --temp-init F    starting temperature (gen 1)    (default: 0.5)
+#   --temp-decay F   temperature multiplier per gen  (default: 0.9)
+#   --temp-min F     minimum temperature floor       (default: 0.05)
+#   --mix-gens N     previous gens to blend in       (default: 3)
+#   --mix-decay F    subsample fraction per older gen (default: 0.5)
+#   --eval-deals N   deals for all evals             (default: 400)
+#   --pimc-param N   pimc rollouts                   (default: 20)
+#   --samples N      sample games to generate        (default: 5)
+#   --seed N         RNG seed                        (default: 42)
+#   --log FILE       append log here                 (default: logs/training.log)
+
+set -euo pipefail
+export LD_LIBRARY_PATH=.venv/lib/python3.13/site-packages/nvidia/cu13/lib
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+START=""
+END=""
+GAMES=200000
+LR_INIT=0.001
+LR_DECAY=0.9
+LR_MIN=0.0001
+TEMP_INIT=0.5
+TEMP_DECAY=0.9
+TEMP_MIN=0.05
+MIX_GENS=3
+MIX_DECAY=0.5
+EVAL_DEALS=400
+PIMC_PARAM=20
+SAMPLES=5
+SEED=42
+LOG_FILE="logs/training.log"
+
+# ── Argument parsing ───────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --start)      START=$2;      shift 2 ;;
+        --end)        END=$2;        shift 2 ;;
+        --games)      GAMES=$2;      shift 2 ;;
+        --lr-init)    LR_INIT=$2;    shift 2 ;;
+        --lr-decay)   LR_DECAY=$2;   shift 2 ;;
+        --lr-min)     LR_MIN=$2;     shift 2 ;;
+        --temp-init)  TEMP_INIT=$2;  shift 2 ;;
+        --temp-decay) TEMP_DECAY=$2; shift 2 ;;
+        --temp-min)   TEMP_MIN=$2;   shift 2 ;;
+        --mix-gens)   MIX_GENS=$2;   shift 2 ;;
+        --mix-decay)  MIX_DECAY=$2;  shift 2 ;;
+        --eval-deals) EVAL_DEALS=$2; shift 2 ;;
+        --pimc-param) PIMC_PARAM=$2; shift 2 ;;
+        --samples)    SAMPLES=$2;    shift 2 ;;
+        --seed)       SEED=$2;       shift 2 ;;
+        --log)        LOG_FILE=$2;   shift 2 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# Auto-detect start generation if not specified
+if [[ -z "$START" ]]; then
+    LATEST=$(ls models/gen[0-9]*.pt models/gen[0-9][0-9]*.pt 2>/dev/null \
+        | grep -oP 'gen\K[0-9]+(?=\.pt)' | sort -n | tail -1)
+    START=$(( ${LATEST:-0} + 1 ))
+fi
+[[ -z "$END" ]] && END=$START
+
+mkdir -p logs data models samples
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+tee_log() {
+    tee -a "$LOG_FILE"
+}
+
+parse_win() {
+    grep -E 'wins:' "$1" | grep -oP '\(\K[^)]+' | head -1
+}
+parse_ci() {
+    grep 'Wilson CI' "$1" | grep -oP '\[.*?\]' | head -1
+}
+# Parse "Deals: WW=N (P%)  split=N (P%)  LL=N (P%)" line
+parse_sweep() {
+    grep -oP 'WW=\d+ \(\K[^%]+' "$1" | head -1
+}
+parse_split() {
+    grep -oP 'split=\d+ \(\K[^%]+' "$1" | head -1
+}
+parse_ll() {
+    grep -oP 'LL=\d+ \(\K[^%]+' "$1" | head -1
+}
+parse_result() {
+    local file=$1
+    printf '%s  %s  WW=%s%%  split=%s%%  LL=%s%%' \
+        "$(parse_win "$file")" "$(parse_ci "$file")" \
+        "$(parse_sweep "$file")" "$(parse_split "$file")" "$(parse_ll "$file")"
+}
+
+ms_to_s() { echo "scale=1; $1/1000" | bc; }
+
+# Compute per-generation LR and temp (exponential decay with floor)
+compute_lr() {
+    local gen=$1
+    python3 -c "print(f'{max($LR_MIN, $LR_INIT * $LR_DECAY**($gen-1)):.6f}')"
+}
+compute_temp() {
+    local gen=$1
+    python3 -c "print(f'{max($TEMP_MIN, $TEMP_INIT * $TEMP_DECAY**($gen-1)):.4f}')"
+}
+
+# ── Main loop ─────────────────────────────────────────────────────────────────
+for GEN in $(seq "$START" "$END"); do
+    PREV=$((GEN - 1))
+    PREV_MODEL="models/gen${PREV}.pt"
+    if [[ ! -f "$PREV_MODEL" ]]; then
+        echo "ERROR: previous model $PREV_MODEL not found" | tee_log; exit 1
+    fi
+
+    LR=$(compute_lr "$GEN")
+    TEMP=$(compute_temp "$GEN")
+
+    {
+        DIV='════════════════════════════════════════════════════════════════════'
+        printf '\n%s\n' "$DIV"
+        printf '  Generation %d   games=%d  epochs=1  lr=%s  temp=%s  mix=%d(x%.1f)\n' \
+            "$GEN" "$GAMES" "$LR" "$TEMP" "$MIX_GENS" "$MIX_DECAY"
+        printf '  %s\n' "$(date '+%Y-%m-%d %H:%M:%S')"
+        printf '%s\n' "$DIV"
+    } | tee_log
+
+    # ── 1. Self-play datagen ─────────────────────────────────────────────────
+    echo "  [1/5] Generating $GAMES games with gen${PREV}..." | tee_log
+    T0=$(date +%s%3N)
+    DATAGEN_OUT=$(mktemp)
+    bin/generate_nn_selfplay \
+        --model  "$PREV_MODEL" \
+        --games  "$GAMES" \
+        --pool   900 \
+        --temp   "$TEMP" \
+        --out    "data/gen${GEN}.parquet" \
+        >"$DATAGEN_OUT" 2>&1
+    grep 'games/s)' "$DATAGEN_OUT" | tail -1 || true
+    DATAGEN_MS=$(( $(date +%s%3N) - T0 ))
+
+    AVG_DP=$(grep  'Avg decision'  "$DATAGEN_OUT" | grep -oP '[\d.]+$' || echo "?")
+    P1_WIN=$(grep  'P1 win rate'   "$DATAGEN_OUT" | grep -oP '\(\K[^)]+' || echo "?")
+    GAMES_S=$(grep 'games/s'       "$DATAGEN_OUT" | grep -oP '[0-9]+ games/s' | tail -1 || echo "?")
+
+    {
+        printf '      avg decision points/game : %s\n' "$AVG_DP"
+        printf '      p1 win rate              : %s\n' "$P1_WIN"
+        printf '      throughput               : %s\n' "$GAMES_S"
+        printf '      time                     : %ss\n' "$(ms_to_s "$DATAGEN_MS")"
+    } | tee_log
+    echo "      legal move count distribution:" | tee_log
+    grep -A 200 'Legal move count' "$DATAGEN_OUT" \
+        | grep -E '^\s+[0-9]' \
+        | awk '{printf "        %s\n", $0}' \
+        | tee_log
+    cat "$DATAGEN_OUT" >> "$LOG_FILE"
+    rm -f "$DATAGEN_OUT"
+
+    # ── 2. Training (1 epoch, exponential generation mixing) ─────────────────
+    echo "  [2/5] Training gen${GEN} (1 epoch, lr=${LR})..." | tee_log
+    T0=$(date +%s%3N)
+
+    # Build file list: current gen first, then older gens up to MIX_GENS back
+    MIX_PARQUETS="data/gen${GEN}.parquet"
+    for i in $(seq 1 "$MIX_GENS"); do
+        prev_gen=$((GEN - i))
+        if [[ "$prev_gen" -ge 1 && -f "data/gen${prev_gen}.parquet" ]]; then
+            MIX_PARQUETS="$MIX_PARQUETS data/gen${prev_gen}.parquet"
+        fi
+    done
+
+    TRAIN_OUT=$(mktemp)
+    # shellcheck disable=SC2086
+    uv run python -m nn.train $MIX_PARQUETS \
+        --out         "models/gen${GEN}.pt" \
+        --epochs      1 \
+        --batch       2048 \
+        --lr          "$LR" \
+        --mix-decay   "$MIX_DECAY" \
+        >"$TRAIN_OUT" 2>&1
+    grep -E '^(Epoch|Loading dataset|Training complete)' "$TRAIN_OUT" || true
+    TRAIN_MS=$(( $(date +%s%3N) - T0 ))
+
+    BEST_LOSS=$(grep 'Best val_loss' "$TRAIN_OUT" | grep -oP '[\d.]+$' || echo "?")
+    FINAL_EPOCH=$(grep '^Epoch' "$TRAIN_OUT" | tail -1 || echo "")
+    {
+        printf '      best val_loss : %s\n' "$BEST_LOSS"
+        [[ -n "$FINAL_EPOCH" ]] && printf '      final epoch   : %s\n' "$FINAL_EPOCH"
+        printf '      time          : %ss\n' "$(ms_to_s "$TRAIN_MS")"
+    } | tee_log
+    cat "$TRAIN_OUT" >> "$LOG_FILE"
+    rm -f "$TRAIN_OUT"
+
+    # ── 3. Evaluations (parallel) ────────────────────────────────────────────
+    echo "  [3/5] Running evals..." | tee_log
+    T0=$(date +%s%3N)
+    E_RANDOM=$(mktemp) E_GREEDY=$(mktemp) E_PIMC=$(mktemp) E_PREV=$(mktemp)
+
+    bin/eval_nn_vs_classic \
+        --model "models/gen${GEN}.pt" --vs random \
+        --deals "$EVAL_DEALS" --seed "$SEED" \
+        >"$E_RANDOM" 2>&1 &
+
+    bin/eval_nn_vs_classic \
+        --model "models/gen${GEN}.pt" --vs greedy \
+        --deals "$EVAL_DEALS" --seed "$SEED" \
+        >"$E_GREEDY" 2>&1 &
+
+    bin/eval_nn_vs_classic \
+        --model "models/gen${GEN}.pt" --vs pimc --vs-param "$PIMC_PARAM" \
+        --deals "$EVAL_DEALS" --seed "$SEED" \
+        >"$E_PIMC" 2>&1 &
+
+    bin/eval_nn_match \
+        --model0 "models/gen${GEN}.pt" \
+        --model1 "$PREV_MODEL" \
+        --deals  "$EVAL_DEALS" --seed "$SEED" \
+        >"$E_PREV" 2>&1 &
+
+    wait
+    EVAL_MS=$(( $(date +%s%3N) - T0 ))
+
+    {
+        printf '      vs random      : %s\n' "$(parse_result "$E_RANDOM")"
+        printf '      vs greedy      : %s\n' "$(parse_result "$E_GREEDY")"
+        printf '      vs pimc(%2d)    : %s\n' "$PIMC_PARAM" "$(parse_result "$E_PIMC")"
+        printf '      vs gen%-2d       : %s\n' "$PREV" "$(parse_result "$E_PREV")"
+        printf '      eval time      : %ss\n' "$(ms_to_s "$EVAL_MS")"
+    } | tee_log
+    rm -f "$E_RANDOM" "$E_GREEDY" "$E_PIMC" "$E_PREV"
+
+    # ── 4. Sample games ──────────────────────────────────────────────────────
+    echo "  [4/5] Generating $SAMPLES sample games..." | tee_log
+    bin/play_games \
+        --model "models/gen${GEN}.pt" \
+        --games "$SAMPLES" \
+        --seed  "$SEED" \
+        --out   "samples/play_gen${GEN}.txt" \
+        2>/dev/null
+    echo "      written to samples/play_gen${GEN}.txt" | tee_log
+
+    # ── 5. Timing summary ────────────────────────────────────────────────────
+    TOTAL_MS=$(( DATAGEN_MS + TRAIN_MS + EVAL_MS ))
+    {
+        printf '\n  Timing:\n'
+        printf '    datagen  %6.1fs\n' "$(ms_to_s "$DATAGEN_MS")"
+        printf '    training %6.1fs\n' "$(ms_to_s "$TRAIN_MS")"
+        printf '    evals    %6.1fs\n' "$(ms_to_s "$EVAL_MS")"
+        printf '    total    %6.1fs\n' "$(ms_to_s "$TOTAL_MS")"
+    } | tee_log
+
+done
+
+echo -e '\n══ Done ══' | tee_log

--- a/scripts/sample_games.py
+++ b/scripts/sample_games.py
@@ -1,0 +1,392 @@
+"""Pretty-print sample games from a self-play parquet file with per-turn decision blocks.
+
+Usage:
+    uv run python scripts/sample_games.py data/gen9.parquet --games 3 --out samples/gen9.txt
+    uv run python scripts/sample_games.py data/gen9.parquet --model models/gen9.pt --games 3 --out samples/gen9.txt
+"""
+from __future__ import annotations
+import argparse, re, numpy as np, pandas as pd
+from pathlib import Path
+
+# ── card / rank constants ──────────────────────────────────────────────────
+R  = ["3","4","5","6","7","8","9","0","J","Q","K","A","2"]
+RM = [4,4,4,4,4,4,4,4,4,4,4,3,1]   # max copies per rank (deck per-player max)
+
+# ── move-ID constants (mirror src/core/util.h) ─────────────────────────────
+kPASS            = 0
+kSINGLE_START    = 1
+kDOUBLE_START    = 14    # +13
+kTRIPLE_START    = 26    # +12
+kFULL_HOUSE_START= 37    # +11
+kBOMB_START      = 169   # +132
+kSTRAIGHT5_START = 325   # +156
+LEGAL_MOVES_SIZE = 468
+
+_SRC = Path(__file__).parent.parent / "src" / "core"
+
+# ── lazy-loaded tables ─────────────────────────────────────────────────────
+_MTCcache: list[list[int]] | None = None
+_KHTcache: list[float]     | None = None
+
+def _mtc() -> list[list[int]]:
+    global _MTCcache
+    if _MTCcache is None:
+        text = (_SRC / "move_to_cards.inc").read_text()
+        result = []
+        for m in re.finditer(r'\{([^{}]+)\}', text):
+            nums = [int(x.strip()) for x in m.group(1).split(',') if x.strip()]
+            if len(nums) == 14:
+                result.append(nums)
+        assert len(result) == LEGAL_MOVES_SIZE
+        _MTCcache = result
+    return _MTCcache
+
+def _kht() -> list[float]:
+    global _KHTcache
+    if _KHTcache is None:
+        text = (_SRC / "hint_table.h").read_text()
+        nums = [float(x) for x in re.findall(r'([\d]+\.[\d]+(?:e[+-]?\d+)?)f', text)]
+        assert len(nums) == LEGAL_MOVES_SIZE
+        _KHTcache = nums
+    return _KHTcache
+
+# ── encoding helpers ───────────────────────────────────────────────────────
+def hbits(at1, at2, at3, at4):
+    return [((at1>>r&1)+((at2>>r&1))+((at3>>r&1))+((at4>>r&1))) for r in range(13)]
+
+def encode_exact(counts):
+    out = []
+    for r, mx in enumerate(RM):
+        c = counts[r]
+        out.extend([(1.0 if c == k else 0.0) for k in range(1, mx+1)])
+    return out
+
+def encode_thermo(counts):
+    out = []
+    for r, mx in enumerate(RM):
+        c = min(counts[r], mx)
+        out.extend([(1.0 if c >= k else 0.0) for k in range(1, mx+1)])
+    return out
+
+# ── move formatting ────────────────────────────────────────────────────────
+def fmt_hand(c: list[int]) -> str:
+    return "".join(R[r] * c[r] for r in range(13))
+
+def fmt_move(mc: list[int] | None, is_pass: bool) -> str:
+    if is_pass or mc is None: return "pass"
+    cards = "".join(R[r]*mc[r] for r in range(13) if mc[r])
+    total = sum(mc)
+    nz = [(r, c) for r, c in enumerate(mc) if c]
+    if total == 1: t = "single"
+    elif total == 2 and len(nz) == 1: t = "pair"
+    elif total == 3 and len(nz) == 1: t = "trips"
+    elif total == 4 and len(nz) == 1 and nz[0][1] == 4: t = "quad"
+    elif total == 5 and len(nz) == 2 and any(c == 3 for _, c in nz): t = "FH"
+    elif total >= 5 and len(nz) == total and all(c == 1 for _, c in nz): t = "str"
+    elif total >= 4 and any(c == 4 for _, c in nz):
+        extra = total - 4
+        t = f"bomb+{extra}" if extra else "bomb"
+    elif total == 3 and len(nz) == 1: t = "3A"  # 3 aces = bare bomb
+    else: t = f"{total}c"
+    return f"{t}({cards})"
+
+# ── move classification ────────────────────────────────────────────────────
+def move_combo_rank(mid: int) -> tuple[str, int]:
+    """(combo_type, rank) – rank is the dominance rank for comparison."""
+    mtc = _mtc()
+    if mid == kPASS: return ("pass", -1)
+    if mid < kDOUBLE_START:    return ("single", mid - kSINGLE_START)
+    if mid < kTRIPLE_START:    return ("pair",   mid - kDOUBLE_START)
+    if mid < kFULL_HOUSE_START:return ("triple", mid - kTRIPLE_START)
+    cards = mtc[mid][:13]
+    if mid < kBOMB_START:
+        triple_r = next(r for r, c in enumerate(cards) if c == 3)
+        return ("fh", triple_r)
+    if mid < kSTRAIGHT5_START:
+        max_c = max(cards)
+        base_r = next(r for r, c in enumerate(cards) if c == max_c)
+        return ("bomb", base_r)
+    # Straight: level = cards per rank slot (1/2/3), rank = highest non-2-low rank
+    max_c = max(cards)
+    nz = [r for r, c in enumerate(cards) if c > 0]
+    # 2-as-low: straight contains rank 12 ("2") AND rank 0 ("3")
+    if 12 in nz and 0 in nz:
+        rank = max(r for r in nz if r != 12)
+    else:
+        rank = max(nz)
+    return (f"str{max_c}", rank)
+
+def beats_move(mid: int, last_mid: int) -> bool:
+    if mid == kPASS: return False
+    tc_n, rc_n = move_combo_rank(mid)
+    tc_l, rc_l = move_combo_rank(last_mid)
+    if tc_n == "bomb" and tc_l != "bomb": return True
+    if tc_n == "bomb" and tc_l == "bomb": return rc_n > rc_l
+    if tc_n != tc_l: return False
+    return rc_n > rc_l
+
+def can_play_move(hand: list[int], mid: int) -> bool:
+    mtc = _mtc()
+    return all(hand[r] >= mtc[mid][r] for r in range(13))
+
+def compute_legal_moves_py(hand: list[int], last_mid: int) -> list[int]:
+    if last_mid == kPASS:
+        return [m for m in range(1, LEGAL_MOVES_SIZE) if can_play_move(hand, m)]
+    return [kPASS] + [m for m in range(1, LEGAL_MOVES_SIZE)
+                      if can_play_move(hand, m) and beats_move(m, last_mid)]
+
+def find_move_id(mc: list[int]) -> int:
+    """Find move_id for given card-count array; returns kPASS if not found."""
+    if sum(mc) == 0: return kPASS
+    mtc = _mtc()
+    mc_l = list(mc)
+    for mid in range(1, LEGAL_MOVES_SIZE):
+        if mtc[mid][:13] == mc_l:
+            return mid
+    return kPASS
+
+# ── model scoring ──────────────────────────────────────────────────────────
+def score_candidates(model, device, hand_before, opp_counts, legal_mids, opp_hand):
+    """Batch-score all legal_mids. Returns [(mid, vi, vn, pt, w)] sorted by w↓."""
+    import torch
+    mtc = _mtc(); kht = _kht()
+    n = len(legal_mids)
+    if n == 0: return []
+
+    # Pre-compute flag (opp definitely can't respond)
+    def opp_cant(move_id):
+        if move_id == kPASS or opp_hand is None: return False
+        return len(compute_legal_moves_py(opp_hand, move_id)) == 1
+
+    hand_arr = np.zeros((n, 48), dtype=np.float32)
+    opp_arr  = np.zeros((n, 48), dtype=np.float32)
+    move_arr = np.zeros((n, 48), dtype=np.float32)
+    hint_arr = np.zeros(n, dtype=np.float32)
+    flag_arr = np.zeros(n, dtype=bool)
+    pass_arr = np.zeros(n, dtype=bool)
+
+    for i, mid in enumerate(legal_mids):
+        mc = mtc[mid][:13] if mid != kPASS else [0]*13
+        hand_after = [hand_before[r] - mc[r] for r in range(13)]
+        is_flag = opp_cant(mid)
+        hint_val = 0.0 if mid == kPASS else (1.0 if is_flag else 1.0 - kht[mid])
+        hand_arr[i] = encode_exact(hand_after)
+        opp_arr[i]  = encode_thermo(opp_counts)
+        move_arr[i] = encode_exact(mc)
+        hint_arr[i] = hint_val
+        flag_arr[i] = is_flag
+        pass_arr[i] = (mid == kPASS)
+
+    with torch.no_grad():
+        vi_t, vn_t, pt_t = model.forward(
+            torch.tensor(hand_arr).to(device),
+            torch.tensor(opp_arr).to(device),
+            torch.tensor(move_arr).to(device),
+            torch.tensor(hint_arr).to(device),
+            torch.tensor(flag_arr).to(device),
+            torch.tensor(pass_arr).to(device),
+        )
+
+    results = []
+    for i, mid in enumerate(legal_mids):
+        vi = vi_t[i].item(); vn = vn_t[i].item(); pt = pt_t[i].item()
+        w = pt * vi + (1 - pt) * vn
+        results.append((mid, vi, vn, pt, w))
+    results.sort(key=lambda x: -x[4])
+    return results
+
+# ── turn-block printer ─────────────────────────────────────────────────────
+_COL = 17   # move string column width
+
+def _score_str(vi, vn, pt, w):
+    return f"pt={pt:.2f} vi={vi:.2f} vn={vn:.2f} w={w:.2f}"
+
+def print_turn(
+    f, trick, p, hand_before, opp_hand, opp_counts,
+    last_trick_mid, last_trick_cards,
+    chosen_mid, chosen_cards,
+    model, device,
+    forced: bool = False,
+    tablebase: bool = False,
+    implicit: bool = False,
+):
+    n_before = sum(hand_before) if hand_before is not None else None
+    n_str    = f"{n_before:2d}" if n_before is not None else " ?"
+    ctx = "Initiative" if last_trick_mid == kPASS else f"vs {fmt_move(last_trick_cards, False)}"
+    tb_tag = "  [tb:opp=1]" if tablebase else ""
+
+    f.write(f"\n  ── T{trick}  P{p}  {n_str} cards  {ctx}{tb_tag} ─\n")
+    hand_str = fmt_hand(hand_before) if hand_before is not None else "?"
+    f.write(f"  Hand [P{p}]: {hand_str}\n")
+    opp_str = fmt_hand(opp_hand) if opp_hand is not None else "?"
+    f.write(f"  Opp  [P{1-p}]: {opp_str}\n")
+
+    is_pass_chosen = (chosen_mid == kPASS)
+
+    if implicit:
+        f.write(f"  ** pass  [implicit]\n")
+        return
+
+    if forced:
+        f.write(f"  ** pass  [forced]\n")
+        return
+
+    if model is None:
+        f.write(f"  ** {fmt_move(chosen_cards, is_pass_chosen)}\n")
+        return
+
+    if hand_before is None:
+        f.write(f"  ** {fmt_move(chosen_cards, is_pass_chosen)}\n")
+        return
+
+    legal = compute_legal_moves_py(hand_before, last_trick_mid)
+
+    # Single-move: forced (should have been caught above, but guard)
+    if len(legal) == 1:
+        f.write(f"  ** {fmt_move(chosen_cards, is_pass_chosen)}  [forced]\n")
+        return
+
+    scored = score_candidates(model, device, hand_before, opp_counts, legal, opp_hand)
+
+    top2 = scored[:2]
+    chosen_in_top2 = any(mid == chosen_mid for mid, *_ in top2)
+
+    for rank_idx, (mid, vi, vn, pt, w) in enumerate(top2):
+        marker = "→" if mid == chosen_mid else " "
+        label  = "#1" if rank_idx == 0 else "#2"
+        mc_i   = _mtc()[mid][:13] if mid != kPASS else [0]*13
+        f.write(f"  {label}{marker} {fmt_move(mc_i, mid==kPASS):<{_COL}}  {_score_str(vi,vn,pt,w)}\n")
+
+    if not chosen_in_top2:
+        for mid, vi, vn, pt, w in scored:
+            if mid == chosen_mid:
+                mc_i = _mtc()[mid][:13] if mid != kPASS else [0]*13
+                f.write(f"  ** {fmt_move(mc_i, mid==kPASS):<{_COL}}  {_score_str(vi,vn,pt,w)}  [played]\n")
+                break
+
+
+# ── game printer ───────────────────────────────────────────────────────────
+def print_game(gdf, f, model=None, device=None):
+    gdf = gdf.sort_values("turn_idx").reset_index(drop=True)
+    winner = gdf["winner"].iloc[0]
+    f.write(f"  {'─'*72}\n")
+
+    exact_hand  = [None, None]  # last known hand per player (after their play)
+    last_mid    = kPASS         # last non-pass move_id (0 = initiative)
+    last_cards  = None          # card counts of last_mid
+    trick       = 1
+    prev_player = None
+    prev_pass   = True          # treat first turn as "just after pass" (initiative)
+
+    for _, row in gdf.iterrows():
+        p        = row["current_player"]
+        opp      = 1 - p
+        is_pass  = bool(row["pass_"])
+        mc       = [row[f"move_at{r}"] for r in range(13)]
+        ha       = hbits(row["hand_at1"], row["hand_at2"], row["hand_at3"], row["hand_at4"])
+        hb       = [ha[r] + mc[r] for r in range(13)]  # hand before this move
+
+        # Opp max-possible counts from parquet (consistent with training)
+        opp_counts = hbits(row["opp_at1"], row["opp_at2"], row["opp_at3"], row["opp_at4"])
+
+        # Detect implicit pass (same player appears twice with no pass row)
+        if prev_player == p and not prev_pass:
+            opp_hb = exact_hand[opp]  # None if opp hasn't played yet
+            if opp_hb is not None:
+                p_counts_as_opp = [RM[r] - opp_hb[r] for r in range(13)]
+                forced_pass = (len(compute_legal_moves_py(opp_hb, last_mid)) == 1)
+            else:
+                # Opponent hasn't played yet; use complement of active player's hand
+                p_counts_as_opp = opp_counts  # from current row's opp_at
+                forced_pass = False  # unknown; don't claim forced
+            print_turn(
+                f, trick, opp, opp_hb, exact_hand[p],
+                p_counts_as_opp,
+                last_mid, last_cards,
+                kPASS, None,
+                model, device,
+                forced=forced_pass,
+                implicit=(opp_hb is None),
+            )
+            # Implicit pass → initiative resets
+            last_mid   = kPASS
+            last_cards = None
+            trick     += 1
+
+        # Detect forced pass for explicit pass rows
+        forced = False
+        if is_pass and last_mid != kPASS:
+            if exact_hand[p] is not None:
+                forced = (len(compute_legal_moves_py(hb, last_mid)) == 1)
+            else:
+                forced = True  # can't verify; assume forced
+
+        chosen_mid = kPASS if is_pass else find_move_id(mc)
+
+        print_turn(
+            f, trick, p, hb, exact_hand[opp],
+            opp_counts,
+            last_mid, last_cards,
+            chosen_mid, mc,
+            model, device,
+            forced=forced,
+            tablebase=(exact_hand[opp] is not None and sum(exact_hand[opp]) == 1),
+        )
+
+        # Update state
+        exact_hand[p] = ha
+        if is_pass:
+            last_mid   = kPASS
+            last_cards = None
+            trick     += 1
+        else:
+            last_mid   = chosen_mid
+            last_cards = mc[:]
+
+        prev_player = p
+        prev_pass   = is_pass
+
+    f.write(f"\n  {'─'*72}\n")
+    f.write(f"  winner: P{winner}\n\n")
+
+
+# ── main ───────────────────────────────────────────────────────────────────
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("parquets", nargs="+")
+    ap.add_argument("--model",  default=None, help="TorchScript .pt model for scoring")
+    ap.add_argument("--games",  type=int, default=3)
+    ap.add_argument("--out",    required=True)
+    ap.add_argument("--seed",   type=int, default=42)
+    args = ap.parse_args()
+
+    model = device = None
+    if args.model:
+        import torch
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        model  = torch.jit.load(args.model, map_location=device)
+        model.eval()
+        print(f"Loaded model: {args.model} on {device}")
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(args.seed)
+
+    with open(args.out, "w") as f:
+        for path in args.parquets:
+            label = Path(path).stem
+            score_label = f"  scored by: {Path(args.model).stem}" if args.model else "  (no scoring model)"
+            f.write(f"\n{'═'*72}\n  {label.upper()}{score_label}\n{'═'*72}\n")
+            df = pd.read_parquet(path)
+            ids = rng.choice(
+                df["game_id"].unique(),
+                size=min(args.games, df["game_id"].nunique()),
+                replace=False,
+            )
+            for i, gid in enumerate(ids, 1):
+                f.write(f"\n  game {i}\n")
+                print_game(df[df["game_id"] == gid], f, model=model, device=device)
+
+    print(f"Wrote {args.out}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sample_games.py
+++ b/scripts/sample_games.py
@@ -4,100 +4,139 @@ Usage:
     uv run python scripts/sample_games.py data/gen9.parquet --games 3 --out samples/gen9.txt
     uv run python scripts/sample_games.py data/gen9.parquet --model models/gen9.pt --games 3 --out samples/gen9.txt
 """
+
 from __future__ import annotations
 import argparse, re, numpy as np, pandas as pd
 from pathlib import Path
 
 # ── card / rank constants ──────────────────────────────────────────────────
-R  = ["3","4","5","6","7","8","9","0","J","Q","K","A","2"]
-RM = [4,4,4,4,4,4,4,4,4,4,4,3,1]   # max copies per rank (deck per-player max)
+R = ["3", "4", "5", "6", "7", "8", "9", "0", "J", "Q", "K", "A", "2"]
+RM = [
+    4,
+    4,
+    4,
+    4,
+    4,
+    4,
+    4,
+    4,
+    4,
+    4,
+    4,
+    3,
+    1,
+]  # max copies per rank (deck per-player max)
 
 # ── move-ID constants (mirror src/core/util.h) ─────────────────────────────
-kPASS            = 0
-kSINGLE_START    = 1
-kDOUBLE_START    = 14    # +13
-kTRIPLE_START    = 26    # +12
-kFULL_HOUSE_START= 37    # +11
-kBOMB_START      = 169   # +132
-kSTRAIGHT5_START = 325   # +156
+kPASS = 0
+kSINGLE_START = 1
+kDOUBLE_START = 14  # +13
+kTRIPLE_START = 26  # +12
+kFULL_HOUSE_START = 37  # +11
+kBOMB_START = 169  # +132
+kSTRAIGHT5_START = 325  # +156
 LEGAL_MOVES_SIZE = 468
 
 _SRC = Path(__file__).parent.parent / "src" / "core"
 
 # ── lazy-loaded tables ─────────────────────────────────────────────────────
 _MTCcache: list[list[int]] | None = None
-_KHTcache: list[float]     | None = None
+_KHTcache: list[float] | None = None
+
 
 def _mtc() -> list[list[int]]:
     global _MTCcache
     if _MTCcache is None:
         text = (_SRC / "move_to_cards.inc").read_text()
         result = []
-        for m in re.finditer(r'\{([^{}]+)\}', text):
-            nums = [int(x.strip()) for x in m.group(1).split(',') if x.strip()]
+        for m in re.finditer(r"\{([^{}]+)\}", text):
+            nums = [int(x.strip()) for x in m.group(1).split(",") if x.strip()]
             if len(nums) == 14:
                 result.append(nums)
         assert len(result) == LEGAL_MOVES_SIZE
         _MTCcache = result
     return _MTCcache
 
+
 def _kht() -> list[float]:
     global _KHTcache
     if _KHTcache is None:
         text = (_SRC / "hint_table.h").read_text()
-        nums = [float(x) for x in re.findall(r'([\d]+\.[\d]+(?:e[+-]?\d+)?)f', text)]
+        nums = [float(x) for x in re.findall(r"([\d]+\.[\d]+(?:e[+-]?\d+)?)f", text)]
         assert len(nums) == LEGAL_MOVES_SIZE
         _KHTcache = nums
     return _KHTcache
 
+
 # ── encoding helpers ───────────────────────────────────────────────────────
 def hbits(at1, at2, at3, at4):
-    return [((at1>>r&1)+((at2>>r&1))+((at3>>r&1))+((at4>>r&1))) for r in range(13)]
+    return [
+        ((at1 >> r & 1) + ((at2 >> r & 1)) + ((at3 >> r & 1)) + ((at4 >> r & 1)))
+        for r in range(13)
+    ]
+
 
 def encode_exact(counts):
     out = []
     for r, mx in enumerate(RM):
         c = counts[r]
-        out.extend([(1.0 if c == k else 0.0) for k in range(1, mx+1)])
+        out.extend([(1.0 if c == k else 0.0) for k in range(1, mx + 1)])
     return out
+
 
 def encode_thermo(counts):
     out = []
     for r, mx in enumerate(RM):
         c = min(counts[r], mx)
-        out.extend([(1.0 if c >= k else 0.0) for k in range(1, mx+1)])
+        out.extend([(1.0 if c >= k else 0.0) for k in range(1, mx + 1)])
     return out
+
 
 # ── move formatting ────────────────────────────────────────────────────────
 def fmt_hand(c: list[int]) -> str:
     return "".join(R[r] * c[r] for r in range(13))
 
+
 def fmt_move(mc: list[int] | None, is_pass: bool) -> str:
-    if is_pass or mc is None: return "pass"
-    cards = "".join(R[r]*mc[r] for r in range(13) if mc[r])
+    if is_pass or mc is None:
+        return "pass"
+    cards = "".join(R[r] * mc[r] for r in range(13) if mc[r])
     total = sum(mc)
     nz = [(r, c) for r, c in enumerate(mc) if c]
-    if total == 1: t = "single"
-    elif total == 2 and len(nz) == 1: t = "pair"
-    elif total == 3 and len(nz) == 1: t = "trips"
-    elif total == 4 and len(nz) == 1 and nz[0][1] == 4: t = "quad"
-    elif total == 5 and len(nz) == 2 and any(c == 3 for _, c in nz): t = "FH"
-    elif total >= 5 and len(nz) == total and all(c == 1 for _, c in nz): t = "str"
+    if total == 1:
+        t = "single"
+    elif total == 2 and len(nz) == 1:
+        t = "pair"
+    elif total == 3 and len(nz) == 1:
+        t = "trips"
+    elif total == 4 and len(nz) == 1 and nz[0][1] == 4:
+        t = "quad"
+    elif total == 5 and len(nz) == 2 and any(c == 3 for _, c in nz):
+        t = "FH"
+    elif total >= 5 and len(nz) == total and all(c == 1 for _, c in nz):
+        t = "str"
     elif total >= 4 and any(c == 4 for _, c in nz):
         extra = total - 4
         t = f"bomb+{extra}" if extra else "bomb"
-    elif total == 3 and len(nz) == 1: t = "3A"  # 3 aces = bare bomb
-    else: t = f"{total}c"
+    elif total == 3 and len(nz) == 1:
+        t = "3A"  # 3 aces = bare bomb
+    else:
+        t = f"{total}c"
     return f"{t}({cards})"
+
 
 # ── move classification ────────────────────────────────────────────────────
 def move_combo_rank(mid: int) -> tuple[str, int]:
     """(combo_type, rank) – rank is the dominance rank for comparison."""
     mtc = _mtc()
-    if mid == kPASS: return ("pass", -1)
-    if mid < kDOUBLE_START:    return ("single", mid - kSINGLE_START)
-    if mid < kTRIPLE_START:    return ("pair",   mid - kDOUBLE_START)
-    if mid < kFULL_HOUSE_START:return ("triple", mid - kTRIPLE_START)
+    if mid == kPASS:
+        return ("pass", -1)
+    if mid < kDOUBLE_START:
+        return ("single", mid - kSINGLE_START)
+    if mid < kTRIPLE_START:
+        return ("pair", mid - kDOUBLE_START)
+    if mid < kFULL_HOUSE_START:
+        return ("triple", mid - kTRIPLE_START)
     cards = mtc[mid][:13]
     if mid < kBOMB_START:
         triple_r = next(r for r, c in enumerate(cards) if c == 3)
@@ -116,28 +155,40 @@ def move_combo_rank(mid: int) -> tuple[str, int]:
         rank = max(nz)
     return (f"str{max_c}", rank)
 
+
 def beats_move(mid: int, last_mid: int) -> bool:
-    if mid == kPASS: return False
+    if mid == kPASS:
+        return False
     tc_n, rc_n = move_combo_rank(mid)
     tc_l, rc_l = move_combo_rank(last_mid)
-    if tc_n == "bomb" and tc_l != "bomb": return True
-    if tc_n == "bomb" and tc_l == "bomb": return rc_n > rc_l
-    if tc_n != tc_l: return False
+    if tc_n == "bomb" and tc_l != "bomb":
+        return True
+    if tc_n == "bomb" and tc_l == "bomb":
+        return rc_n > rc_l
+    if tc_n != tc_l:
+        return False
     return rc_n > rc_l
+
 
 def can_play_move(hand: list[int], mid: int) -> bool:
     mtc = _mtc()
     return all(hand[r] >= mtc[mid][r] for r in range(13))
 
+
 def compute_legal_moves_py(hand: list[int], last_mid: int) -> list[int]:
     if last_mid == kPASS:
         return [m for m in range(1, LEGAL_MOVES_SIZE) if can_play_move(hand, m)]
-    return [kPASS] + [m for m in range(1, LEGAL_MOVES_SIZE)
-                      if can_play_move(hand, m) and beats_move(m, last_mid)]
+    return [kPASS] + [
+        m
+        for m in range(1, LEGAL_MOVES_SIZE)
+        if can_play_move(hand, m) and beats_move(m, last_mid)
+    ]
+
 
 def find_move_id(mc: list[int]) -> int:
     """Find move_id for given card-count array; returns kPASS if not found."""
-    if sum(mc) == 0: return kPASS
+    if sum(mc) == 0:
+        return kPASS
     mtc = _mtc()
     mc_l = list(mc)
     for mid in range(1, LEGAL_MOVES_SIZE):
@@ -145,37 +196,42 @@ def find_move_id(mc: list[int]) -> int:
             return mid
     return kPASS
 
+
 # ── model scoring ──────────────────────────────────────────────────────────
 def score_candidates(model, device, hand_before, opp_counts, legal_mids, opp_hand):
     """Batch-score all legal_mids. Returns [(mid, vi, vn, pt, w)] sorted by w↓."""
     import torch
-    mtc = _mtc(); kht = _kht()
+
+    mtc = _mtc()
+    kht = _kht()
     n = len(legal_mids)
-    if n == 0: return []
+    if n == 0:
+        return []
 
     # Pre-compute flag (opp definitely can't respond)
     def opp_cant(move_id):
-        if move_id == kPASS or opp_hand is None: return False
+        if move_id == kPASS or opp_hand is None:
+            return False
         return len(compute_legal_moves_py(opp_hand, move_id)) == 1
 
     hand_arr = np.zeros((n, 48), dtype=np.float32)
-    opp_arr  = np.zeros((n, 48), dtype=np.float32)
+    opp_arr = np.zeros((n, 48), dtype=np.float32)
     move_arr = np.zeros((n, 48), dtype=np.float32)
     hint_arr = np.zeros(n, dtype=np.float32)
     flag_arr = np.zeros(n, dtype=bool)
     pass_arr = np.zeros(n, dtype=bool)
 
     for i, mid in enumerate(legal_mids):
-        mc = mtc[mid][:13] if mid != kPASS else [0]*13
+        mc = mtc[mid][:13] if mid != kPASS else [0] * 13
         hand_after = [hand_before[r] - mc[r] for r in range(13)]
         is_flag = opp_cant(mid)
         hint_val = 0.0 if mid == kPASS else (1.0 if is_flag else 1.0 - kht[mid])
         hand_arr[i] = encode_exact(hand_after)
-        opp_arr[i]  = encode_thermo(opp_counts)
+        opp_arr[i] = encode_thermo(opp_counts)
         move_arr[i] = encode_exact(mc)
         hint_arr[i] = hint_val
         flag_arr[i] = is_flag
-        pass_arr[i] = (mid == kPASS)
+        pass_arr[i] = mid == kPASS
 
     with torch.no_grad():
         vi_t, vn_t, pt_t = model.forward(
@@ -189,30 +245,47 @@ def score_candidates(model, device, hand_before, opp_counts, legal_mids, opp_han
 
     results = []
     for i, mid in enumerate(legal_mids):
-        vi = vi_t[i].item(); vn = vn_t[i].item(); pt = pt_t[i].item()
+        vi = vi_t[i].item()
+        vn = vn_t[i].item()
+        pt = pt_t[i].item()
         w = pt * vi + (1 - pt) * vn
         results.append((mid, vi, vn, pt, w))
     results.sort(key=lambda x: -x[4])
     return results
 
+
 # ── turn-block printer ─────────────────────────────────────────────────────
-_COL = 17   # move string column width
+_COL = 17  # move string column width
+
 
 def _score_str(vi, vn, pt, w):
     return f"pt={pt:.2f} vi={vi:.2f} vn={vn:.2f} w={w:.2f}"
 
+
 def print_turn(
-    f, trick, p, hand_before, opp_hand, opp_counts,
-    last_trick_mid, last_trick_cards,
-    chosen_mid, chosen_cards,
-    model, device,
+    f,
+    trick,
+    p,
+    hand_before,
+    opp_hand,
+    opp_counts,
+    last_trick_mid,
+    last_trick_cards,
+    chosen_mid,
+    chosen_cards,
+    model,
+    device,
     forced: bool = False,
     tablebase: bool = False,
     implicit: bool = False,
 ):
     n_before = sum(hand_before) if hand_before is not None else None
-    n_str    = f"{n_before:2d}" if n_before is not None else " ?"
-    ctx = "Initiative" if last_trick_mid == kPASS else f"vs {fmt_move(last_trick_cards, False)}"
+    n_str = f"{n_before:2d}" if n_before is not None else " ?"
+    ctx = (
+        "Initiative"
+        if last_trick_mid == kPASS
+        else f"vs {fmt_move(last_trick_cards, False)}"
+    )
     tb_tag = "  [tb:opp=1]" if tablebase else ""
 
     f.write(f"\n  ── T{trick}  P{p}  {n_str} cards  {ctx}{tb_tag} ─\n")
@@ -221,7 +294,7 @@ def print_turn(
     opp_str = fmt_hand(opp_hand) if opp_hand is not None else "?"
     f.write(f"  Opp  [P{1-p}]: {opp_str}\n")
 
-    is_pass_chosen = (chosen_mid == kPASS)
+    is_pass_chosen = chosen_mid == kPASS
 
     if implicit:
         f.write(f"  ** pass  [implicit]\n")
@@ -253,15 +326,19 @@ def print_turn(
 
     for rank_idx, (mid, vi, vn, pt, w) in enumerate(top2):
         marker = "→" if mid == chosen_mid else " "
-        label  = "#1" if rank_idx == 0 else "#2"
-        mc_i   = _mtc()[mid][:13] if mid != kPASS else [0]*13
-        f.write(f"  {label}{marker} {fmt_move(mc_i, mid==kPASS):<{_COL}}  {_score_str(vi,vn,pt,w)}\n")
+        label = "#1" if rank_idx == 0 else "#2"
+        mc_i = _mtc()[mid][:13] if mid != kPASS else [0] * 13
+        f.write(
+            f"  {label}{marker} {fmt_move(mc_i, mid==kPASS):<{_COL}}  {_score_str(vi,vn,pt,w)}\n"
+        )
 
     if not chosen_in_top2:
         for mid, vi, vn, pt, w in scored:
             if mid == chosen_mid:
-                mc_i = _mtc()[mid][:13] if mid != kPASS else [0]*13
-                f.write(f"  ** {fmt_move(mc_i, mid==kPASS):<{_COL}}  {_score_str(vi,vn,pt,w)}  [played]\n")
+                mc_i = _mtc()[mid][:13] if mid != kPASS else [0] * 13
+                f.write(
+                    f"  ** {fmt_move(mc_i, mid==kPASS):<{_COL}}  {_score_str(vi,vn,pt,w)}  [played]\n"
+                )
                 break
 
 
@@ -271,64 +348,80 @@ def print_game(gdf, f, model=None, device=None):
     winner = gdf["winner"].iloc[0]
     f.write(f"  {'─'*72}\n")
 
-    exact_hand  = [None, None]  # last known hand per player (after their play)
-    last_mid    = kPASS         # last non-pass move_id (0 = initiative)
-    last_cards  = None          # card counts of last_mid
-    trick       = 1
+    exact_hand = [None, None]  # last known hand per player (after their play)
+    last_mid = kPASS  # last non-pass move_id (0 = initiative)
+    last_cards = None  # card counts of last_mid
+    trick = 1
     prev_player = None
-    prev_pass   = True          # treat first turn as "just after pass" (initiative)
+    prev_pass = True  # treat first turn as "just after pass" (initiative)
 
     for _, row in gdf.iterrows():
-        p        = row["current_player"]
-        opp      = 1 - p
-        is_pass  = bool(row["pass_"])
-        mc       = [row[f"move_at{r}"] for r in range(13)]
-        ha       = hbits(row["hand_at1"], row["hand_at2"], row["hand_at3"], row["hand_at4"])
-        hb       = [ha[r] + mc[r] for r in range(13)]  # hand before this move
+        p = row["current_player"]
+        opp = 1 - p
+        is_pass = bool(row["pass_"])
+        mc = [row[f"move_at{r}"] for r in range(13)]
+        ha = hbits(row["hand_at1"], row["hand_at2"], row["hand_at3"], row["hand_at4"])
+        hb = [ha[r] + mc[r] for r in range(13)]  # hand before this move
 
         # Opp max-possible counts from parquet (consistent with training)
-        opp_counts = hbits(row["opp_at1"], row["opp_at2"], row["opp_at3"], row["opp_at4"])
+        opp_counts = hbits(
+            row["opp_at1"], row["opp_at2"], row["opp_at3"], row["opp_at4"]
+        )
 
         # Detect implicit pass (same player appears twice with no pass row)
         if prev_player == p and not prev_pass:
             opp_hb = exact_hand[opp]  # None if opp hasn't played yet
             if opp_hb is not None:
                 p_counts_as_opp = [RM[r] - opp_hb[r] for r in range(13)]
-                forced_pass = (len(compute_legal_moves_py(opp_hb, last_mid)) == 1)
+                forced_pass = len(compute_legal_moves_py(opp_hb, last_mid)) == 1
             else:
                 # Opponent hasn't played yet; use complement of active player's hand
                 p_counts_as_opp = opp_counts  # from current row's opp_at
                 forced_pass = False  # unknown; don't claim forced
             print_turn(
-                f, trick, opp, opp_hb, exact_hand[p],
+                f,
+                trick,
+                opp,
+                opp_hb,
+                exact_hand[p],
                 p_counts_as_opp,
-                last_mid, last_cards,
-                kPASS, None,
-                model, device,
+                last_mid,
+                last_cards,
+                kPASS,
+                None,
+                model,
+                device,
                 forced=forced_pass,
                 implicit=(opp_hb is None),
             )
             # Implicit pass → initiative resets
-            last_mid   = kPASS
+            last_mid = kPASS
             last_cards = None
-            trick     += 1
+            trick += 1
 
         # Detect forced pass for explicit pass rows
         forced = False
         if is_pass and last_mid != kPASS:
             if exact_hand[p] is not None:
-                forced = (len(compute_legal_moves_py(hb, last_mid)) == 1)
+                forced = len(compute_legal_moves_py(hb, last_mid)) == 1
             else:
                 forced = True  # can't verify; assume forced
 
         chosen_mid = kPASS if is_pass else find_move_id(mc)
 
         print_turn(
-            f, trick, p, hb, exact_hand[opp],
+            f,
+            trick,
+            p,
+            hb,
+            exact_hand[opp],
             opp_counts,
-            last_mid, last_cards,
-            chosen_mid, mc,
-            model, device,
+            last_mid,
+            last_cards,
+            chosen_mid,
+            mc,
+            model,
+            device,
             forced=forced,
             tablebase=(exact_hand[opp] is not None and sum(exact_hand[opp]) == 1),
         )
@@ -336,15 +429,15 @@ def print_game(gdf, f, model=None, device=None):
         # Update state
         exact_hand[p] = ha
         if is_pass:
-            last_mid   = kPASS
+            last_mid = kPASS
             last_cards = None
-            trick     += 1
+            trick += 1
         else:
-            last_mid   = chosen_mid
+            last_mid = chosen_mid
             last_cards = mc[:]
 
         prev_player = p
-        prev_pass   = is_pass
+        prev_pass = is_pass
 
     f.write(f"\n  {'─'*72}\n")
     f.write(f"  winner: P{winner}\n\n")
@@ -354,17 +447,18 @@ def print_game(gdf, f, model=None, device=None):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("parquets", nargs="+")
-    ap.add_argument("--model",  default=None, help="TorchScript .pt model for scoring")
-    ap.add_argument("--games",  type=int, default=3)
-    ap.add_argument("--out",    required=True)
-    ap.add_argument("--seed",   type=int, default=42)
+    ap.add_argument("--model", default=None, help="TorchScript .pt model for scoring")
+    ap.add_argument("--games", type=int, default=3)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--seed", type=int, default=42)
     args = ap.parse_args()
 
     model = device = None
     if args.model:
         import torch
+
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        model  = torch.jit.load(args.model, map_location=device)
+        model = torch.jit.load(args.model, map_location=device)
         model.eval()
         print(f"Loaded model: {args.model} on {device}")
 
@@ -374,7 +468,11 @@ def main():
     with open(args.out, "w") as f:
         for path in args.parquets:
             label = Path(path).stem
-            score_label = f"  scored by: {Path(args.model).stem}" if args.model else "  (no scoring model)"
+            score_label = (
+                f"  scored by: {Path(args.model).stem}"
+                if args.model
+                else "  (no scoring model)"
+            )
             f.write(f"\n{'═'*72}\n  {label.upper()}{score_label}\n{'═'*72}\n")
             df = pd.read_parquet(path)
             ids = rng.choice(
@@ -387,6 +485,7 @@ def main():
                 print_game(df[df["game_id"] == gid], f, model=model, device=device)
 
     print(f"Wrote {args.out}")
+
 
 if __name__ == "__main__":
     main()

--- a/src/core/util.cpp
+++ b/src/core/util.cpp
@@ -211,22 +211,34 @@ std::vector<int> compute_legal_moves(const HandBits &hand,
   const int lr = last_move.rank;
   const int bc = static_cast<int>(Move::Combination::kBomb);
 
+  // Bug fix: Move::rank uses card face values (3=three, 13=K, 14=A, 2=two),
+  // but HandBits bit positions are rank indices (0=three, 10=K, 11=A, 12=two).
+  // Convert rank → rank_idx before using as a bit shift.
+  // The "two" card has face rank 2 but is the highest (rank_idx 12).
+  auto rank_to_idx = [](int rank) -> int {
+      return (rank == 2) ? 12 : (rank - 3);
+  };
+
   if (lc == static_cast<int>(Move::Combination::kSingle)) {
-      for (uint16_t b = static_cast<uint16_t>(hand.at1 >> (lr + 1)); b;
+      const int li = rank_to_idx(lr);
+      for (uint16_t b = static_cast<uint16_t>(hand.at1 >> (li + 1)); b;
            b &= static_cast<uint16_t>(b - 1))
-          legal.push_back(kSINGLE_START + lr + 1 + __builtin_ctz(b));
+          legal.push_back(kSINGLE_START + li + 1 + __builtin_ctz(b));
   } else if (lc == static_cast<int>(Move::Combination::kDouble)) {
-      for (uint16_t b = static_cast<uint16_t>(hand.at2 >> (lr + 1)); b;
+      const int li = rank_to_idx(lr);
+      for (uint16_t b = static_cast<uint16_t>(hand.at2 >> (li + 1)); b;
            b &= static_cast<uint16_t>(b - 1))
-          legal.push_back(kDOUBLE_START + lr + 1 + __builtin_ctz(b));
+          legal.push_back(kDOUBLE_START + li + 1 + __builtin_ctz(b));
   } else if (lc == static_cast<int>(Move::Combination::kTriple)) {
-      for (uint16_t b = static_cast<uint16_t>((hand.at3 & 0x07FFu) >> (lr + 1)); b;
+      const int li = rank_to_idx(lr);
+      for (uint16_t b = static_cast<uint16_t>((hand.at3 & 0x07FFu) >> (li + 1)); b;
            b &= static_cast<uint16_t>(b - 1))
-          legal.push_back(kTRIPLE_START + lr + 1 + __builtin_ctz(b));
+          legal.push_back(kTRIPLE_START + li + 1 + __builtin_ctz(b));
   } else if (lc == static_cast<int>(Move::Combination::kFullHouse)) {
-      for (uint16_t tb = static_cast<uint16_t>(hand.at3 >> (lr + 1)); tb;
+      const int li = rank_to_idx(lr);
+      for (uint16_t tb = static_cast<uint16_t>(hand.at3 >> (li + 1)); tb;
            tb &= static_cast<uint16_t>(tb - 1)) {
-          const int t = lr + 1 + __builtin_ctz(tb);
+          const int t = li + 1 + __builtin_ctz(tb);
           for (uint16_t kb = static_cast<uint16_t>(hand.at2 & ~(1u << t)); kb;
                kb &= static_cast<uint16_t>(kb - 1)) {
               const int16_t fh = tbl.fh[t][__builtin_ctz(kb)];
@@ -234,14 +246,16 @@ std::vector<int> compute_legal_moves(const HandBits &hand,
           }
       }
   } else if (lc != bc) {
-      // Straight response: table lookup + filter by rank > lr
+      // Straight response: same width AND same length, higher rank.
       const int level = combo_to_straight_level(lc);
       if (level >= 0) {
           const uint16_t at = (level == 0) ? hand.at1 :
                               (level == 1) ? hand.at2 : hand.at3;
           const auto &mvs = all_moves();
+          const Move::Combination last_combo = last_move.combination;
           for (uint16_t mid : tbl.straight[level][at & 0x1FFFu])
-              if (mvs[mid].rank > lr) legal.push_back(mid);
+              if (mvs[mid].combination == last_combo && mvs[mid].rank > lr)
+                  legal.push_back(mid);
       }
   }
 

--- a/src/datagen/eval_helpers.h
+++ b/src/datagen/eval_helpers.h
@@ -1,0 +1,185 @@
+#pragma once
+// Shared utilities for pool-based batched NN evaluation.
+
+#include "game.h"
+#include "hint_table.h"
+#include "move.h"
+#include "nn_encode.h"
+#include "tablebase_opp1.h"
+#include "util.h"
+
+#include <torch/script.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <tuple>
+#include <vector>
+
+// ============================================================================
+// Wilson CI
+// ============================================================================
+
+struct WilsonCI { double lo, hi; };
+inline WilsonCI wilson_ci(double p_hat, long n, double z = 1.96) {
+    double z2 = z*z, n_inv = 1.0/(double)n;
+    double center = (p_hat + z2*n_inv/2.0) / (1.0 + z2*n_inv);
+    double half = z * std::sqrt(p_hat*(1.0-p_hat)*n_inv + z2*n_inv*n_inv/4.0) /
+                  (1.0 + z2*n_inv);
+    return {center - half, center + half};
+}
+
+inline std::string format_elapsed(long long ms) {
+    if (ms < 1000) { char b[32]; std::snprintf(b, sizeof(b), "%lld ms", ms); return b; }
+    double s = ms / 1000.0; char b[64];
+    if (s < 60) std::snprintf(b, sizeof(b), "%.1f s", s);
+    else        std::snprintf(b, sizeof(b), "%dm %ds", (int)(s/60), (int)s%60);
+    return b;
+}
+
+// ============================================================================
+// Game-level tablebase (mirrors nn_game_runner.cpp)
+// ============================================================================
+
+inline int tablebase_move_id(const Game& game, int cp, const std::vector<int>& legal) {
+    auto hand      = game.player_hand(cp);
+    int  hand_size = game.get_player_hand_size(cp);
+    int  opp_size  = game.get_player_hand_size(1 - cp);
+
+    for (int mid : legal) {
+        if (mid == kPASS) continue;
+        if (MOVE_TO_CARDS[mid][13] == hand_size) return mid;
+    }
+    if (game.last_move().combination != Move::Combination::kPass) return -1;
+
+    auto discard = game.discard_pile();
+    if (opp_size == 1) {
+        int best_rank = -1; bool all_singles = true;
+        for (int mid : legal) {
+            if (mid == kPASS) continue;
+            Move m(mid);
+            if (m.combination != Move::Combination::kSingle) { all_singles = false; break; }
+            if (m.rank > best_rank) best_rank = m.rank;
+        }
+        if (all_singles && best_rank != -1) {
+            for (int mid : legal)
+                if (mid != kPASS && Move(mid).rank == best_rank) return mid;
+        }
+        Opp1Result opp1 = lookup_opp1(hand);
+        if (opp1.first_move_id != 0) {
+            for (int mid : legal) if (mid == opp1.first_move_id) return mid;
+        }
+        if (auto def = opp1_default_strategy_move(hand)) return *def;
+    }
+    auto seq = find_forced_win(hand, discard, opp_size);
+    if (seq) return (*seq)[0];
+    return -1;
+}
+
+// ============================================================================
+// Batched NN inference
+//
+// positions[i] = {game_ptr, cp, legal_moves_ptr}
+// Returns best legal-move index (into legal_moves) for each position.
+// ============================================================================
+
+using NNPosition = std::tuple<const Game*, int, const std::vector<int>*>;
+
+inline std::vector<int> batch_nn_select(
+    torch::jit::Module& model,
+    torch::Device device,
+    const std::vector<NNPosition>& positions)
+{
+    if (positions.empty()) return {};
+
+    int total_k = 0;
+    std::vector<int> offsets(positions.size()), sizes(positions.size());
+    for (int i = 0; i < (int)positions.size(); ++i) {
+        offsets[i] = total_k;
+        sizes[i]   = (int)std::get<2>(positions[i])->size();
+        total_k   += sizes[i];
+    }
+
+    auto float_opts = torch::TensorOptions().dtype(torch::kFloat32);
+    auto bool_opts  = torch::TensorOptions().dtype(torch::kBool);
+    auto t_hand = torch::zeros({total_k, ENCODING_DIM}, float_opts);
+    auto t_opp  = torch::zeros({total_k, ENCODING_DIM}, float_opts);
+    auto t_move = torch::zeros({total_k, ENCODING_DIM}, float_opts);
+    auto t_hint = torch::zeros({total_k}, float_opts);
+    auto t_flag = torch::zeros({total_k}, bool_opts);
+    auto t_pass = torch::zeros({total_k}, bool_opts);
+
+    float* h_hand = t_hand.data_ptr<float>();
+    float* h_opp  = t_opp.data_ptr<float>();
+    float* h_move = t_move.data_ptr<float>();
+    float* h_hint = t_hint.data_ptr<float>();
+    bool*  h_flag = t_flag.data_ptr<bool>();
+    bool*  h_pass = t_pass.data_ptr<bool>();
+
+    for (int i = 0; i < (int)positions.size(); ++i) {
+        const Game&              game  = *std::get<0>(positions[i]);
+        int                      cp    = std::get<1>(positions[i]);
+        const std::vector<int>&  legal = *std::get<2>(positions[i]);
+        int K = sizes[i], off = offsets[i];
+
+        auto hand_counts = game.player_hand(cp);
+        auto discard     = game.discard_pile();
+        int  opp_count   = game.get_player_hand_size(1 - cp);
+
+        std::array<int,13> opp_counts{};
+        HandBits opp_bits{};
+        for (int r = 0; r < 13; ++r) {
+            int om = std::max(0, max_cards_in_deck_for_rank(r) - hand_counts[r] - discard[r]);
+            opp_counts[r] = om;
+            if (om >= 1) opp_bits.at1 |= static_cast<uint16_t>(1u << r);
+            if (om >= 2) opp_bits.at2 |= static_cast<uint16_t>(1u << r);
+            if (om >= 3) opp_bits.at3 |= static_cast<uint16_t>(1u << r);
+            if (om >= 4) opp_bits.at4 |= static_cast<uint16_t>(1u << r);
+        }
+
+        for (int j = 0; j < K; ++j) {
+            int mid = legal[j];
+            bool is_pass = (mid == kPASS);
+            std::array<int,13> mc{}, hand_after{};
+            if (!is_pass)
+                for (int r = 0; r < 13; ++r) mc[r] = MOVE_TO_CARDS[mid][r];
+            for (int r = 0; r < 13; ++r) hand_after[r] = hand_counts[r] - mc[r];
+
+            encode_exact(hand_after,  h_hand + (off+j) * ENCODING_DIM);
+            encode_thermo(opp_counts, h_opp  + (off+j) * ENCODING_DIM);
+            encode_exact(mc,          h_move + (off+j) * ENCODING_DIM);
+
+            bool flag = !is_pass && !opponent_can_respond(mid, opp_bits, opp_count);
+            h_hint[off+j] = is_pass ? 0.0f : (flag ? 1.0f : (1.0f - kHintTable[mid]));
+            h_flag[off+j] = flag;
+            h_pass[off+j] = is_pass;
+        }
+    }
+
+    torch::NoGradGuard no_grad;
+    auto out = model.forward({
+        t_hand.to(device), t_opp.to(device), t_move.to(device),
+        t_hint.to(device), t_flag.to(device), t_pass.to(device)
+    }).toTuple();
+
+    auto vi = out->elements()[0].toTensor().to(torch::kCPU);
+    auto vn = out->elements()[1].toTensor().to(torch::kCPU);
+    auto pt = out->elements()[2].toTensor().to(torch::kCPU);
+    const float* vi_p = vi.data_ptr<float>();
+    const float* vn_p = vn.data_ptr<float>();
+    const float* pt_p = pt.data_ptr<float>();
+
+    std::vector<int> result(positions.size());
+    for (int i = 0; i < (int)positions.size(); ++i) {
+        int off = offsets[i], K = sizes[i];
+        int best = 0; float best_w = -1.0f;
+        for (int j = 0; j < K; ++j) {
+            float w = pt_p[off+j] * vi_p[off+j] + (1.0f - pt_p[off+j]) * vn_p[off+j];
+            if (w > best_w) { best_w = w; best = j; }
+        }
+        result[i] = best;
+    }
+    return result;
+}

--- a/src/datagen/eval_nn_match.cpp
+++ b/src/datagen/eval_nn_match.cpp
@@ -1,0 +1,284 @@
+// eval_nn_match: head-to-head evaluation between two TorchScript NN models.
+//
+// Uses paired deals (same shuffle, seats swapped) so card luck cancels.
+// Single-threaded; CPU inference is fast enough for ~1k deals (<30s).
+//
+// Usage:
+//   eval_nn_match --model0 PATH --model1 PATH --deals N [--seed S]
+//                 [--device auto|cpu|cuda]
+
+#include "nn_game_runner.h"
+#include "nn_encode.h"
+
+#include "game.h"
+#include "hint_table.h"
+#include "util.h"
+
+#include <torch/script.h>
+#include <torch/cuda.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <random>
+#include <string>
+
+// ============================================================================
+// Wilson score 95% confidence interval for a proportion
+// ============================================================================
+
+struct WilsonCI { double lo, hi; };
+
+static WilsonCI wilson_ci(double p_hat, long n, double z = 1.96) {
+    double z2 = z * z, n_inv = 1.0 / (double)n;
+    double center = (p_hat + z2 * n_inv / 2.0) / (1.0 + z2 * n_inv);
+    double half = z * std::sqrt(p_hat * (1.0 - p_hat) * n_inv + z2 * n_inv * n_inv / 4.0) /
+                  (1.0 + z2 * n_inv);
+    return {center - half, center + half};
+}
+
+// ============================================================================
+// NN PolicyFn factory
+//
+// Encodes all K legal moves for the current position, runs a single batched
+// forward pass, and returns the move with highest expected value
+// w = p_trick * v_init + (1 - p_trick) * v_no_init.
+// ============================================================================
+
+static PolicyFn make_nn_policy(torch::jit::Module& model, torch::Device device) {
+    return [&model, device](const Game& game, int player_num,
+                             const std::vector<int>& legal_moves) -> int {
+        const int K = (int)legal_moves.size();
+
+        HandBits hb      = game.player_hand_bits(player_num);
+        auto discard     = game.discard_pile();
+        auto hand_counts = hand_bits_to_counts(hb);
+        int  opp_count   = game.get_player_hand_size(1 - player_num);
+
+        // Opponent max possible counts + HandBits for respond check
+        std::array<int,13> opp_counts{};
+        HandBits opp_bits{};
+        for (int r = 0; r < 13; ++r) {
+            int hand_r = ((hb.at1>>r)&1)+((hb.at2>>r)&1)+((hb.at3>>r)&1)+((hb.at4>>r)&1);
+            int om = std::max(0, max_cards_in_deck_for_rank(r) - hand_r - discard[r]);
+            opp_counts[r] = om;
+            if (om >= 1) opp_bits.at1 |= static_cast<uint16_t>(1u << r);
+            if (om >= 2) opp_bits.at2 |= static_cast<uint16_t>(1u << r);
+            if (om >= 3) opp_bits.at3 |= static_cast<uint16_t>(1u << r);
+            if (om >= 4) opp_bits.at4 |= static_cast<uint16_t>(1u << r);
+        }
+
+        auto float_opts = torch::TensorOptions().dtype(torch::kFloat32);
+        auto bool_opts  = torch::TensorOptions().dtype(torch::kBool);
+        torch::Tensor t_hand = torch::zeros({K, ENCODING_DIM}, float_opts);
+        torch::Tensor t_opp  = torch::zeros({K, ENCODING_DIM}, float_opts);
+        torch::Tensor t_move = torch::zeros({K, ENCODING_DIM}, float_opts);
+        torch::Tensor t_hint = torch::zeros({K}, float_opts);
+        torch::Tensor t_flag = torch::zeros({K}, bool_opts);
+        torch::Tensor t_pass = torch::zeros({K}, bool_opts);
+
+        float* h_hand = t_hand.data_ptr<float>();
+        float* h_opp  = t_opp.data_ptr<float>();
+        float* h_move = t_move.data_ptr<float>();
+        float* h_hint = t_hint.data_ptr<float>();
+        bool*  h_flag = t_flag.data_ptr<bool>();
+        bool*  h_pass = t_pass.data_ptr<bool>();
+
+        for (int i = 0; i < K; ++i) {
+            int mid = legal_moves[i];
+            bool is_pass_move = (mid == kPASS);
+
+            std::array<int,13> mc{};
+            if (!is_pass_move)
+                for (int r = 0; r < 13; ++r) mc[r] = MOVE_TO_CARDS[mid][r];
+
+            // Hand after playing this move (model input is post-move hand)
+            std::array<int,13> hand_after{};
+            for (int r = 0; r < 13; ++r) hand_after[r] = hand_counts[r] - mc[r];
+
+            encode_exact(hand_after,  h_hand + i * ENCODING_DIM);
+            encode_thermo(opp_counts, h_opp  + i * ENCODING_DIM);
+            encode_exact(mc,          h_move + i * ENCODING_DIM);
+
+            bool flag_val = !is_pass_move && !opponent_can_respond(mid, opp_bits, opp_count);
+            h_hint[i] = is_pass_move ? 0.0f : (flag_val ? 1.0f : (1.0f - kHintTable[mid]));
+            h_flag[i] = flag_val;
+            h_pass[i] = is_pass_move;
+        }
+
+        torch::NoGradGuard no_grad;
+        auto out = model.forward({
+            t_hand.to(device), t_opp.to(device), t_move.to(device),
+            t_hint.to(device), t_flag.to(device), t_pass.to(device)
+        }).toTuple();
+
+        auto vi  = out->elements()[0].toTensor().to(torch::kCPU);
+        auto vn  = out->elements()[1].toTensor().to(torch::kCPU);
+        auto pt  = out->elements()[2].toTensor().to(torch::kCPU);
+        auto* vi_p = vi.data_ptr<float>();
+        auto* vn_p = vn.data_ptr<float>();
+        auto* pt_p = pt.data_ptr<float>();
+
+        int   best   = 0;
+        float best_w = -1.0f;
+        for (int i = 0; i < K; ++i) {
+            float w = pt_p[i] * vi_p[i] + (1.0f - pt_p[i]) * vn_p[i];
+            if (w > best_w) { best_w = w; best = i; }
+        }
+        return legal_moves[best];
+    };
+}
+
+// ============================================================================
+// Reporting helpers (shared with eval_match style)
+// ============================================================================
+
+static std::string format_elapsed(long long ms) {
+    if (ms < 1000) { char b[32]; std::snprintf(b, sizeof(b), "%lld ms", ms); return b; }
+    double s = ms / 1000.0;
+    char b[64];
+    if (s < 60) std::snprintf(b, sizeof(b), "%.1f s", s);
+    else        std::snprintf(b, sizeof(b), "%dm %ds", (int)(s/60), (int)s%60);
+    return b;
+}
+
+static void print_usage(const char* prog) {
+    std::cout << "Usage: " << prog
+              << " --model0 PATH --model1 PATH --deals N [--seed S] [--device auto|cpu|cuda]\n"
+              << "Options:\n"
+              << "  --model0 PATH    Model A (TorchScript .pt)\n"
+              << "  --model1 PATH    Model B (TorchScript .pt)\n"
+              << "  --deals N        Paired deals; total games = 2*N\n"
+              << "  --seed S         RNG seed (default: random)\n"
+              << "  --device D       auto|cpu|cuda (default: auto)\n";
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char** argv) {
+    std::string model0_path, model1_path, device_str = "auto";
+    int n_deals = 0;
+    unsigned int seed = std::random_device{}();
+
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if      (a == "--help"   || a == "-h")  { print_usage(argv[0]); return 0; }
+        else if (a == "--model0" && i+1 < argc)  model0_path = argv[++i];
+        else if (a == "--model1" && i+1 < argc)  model1_path = argv[++i];
+        else if (a == "--deals"  && i+1 < argc)  n_deals     = std::stoi(argv[++i]);
+        else if (a == "--seed"   && i+1 < argc)  seed        = (unsigned)std::stoul(argv[++i]);
+        else if (a == "--device" && i+1 < argc)  device_str  = argv[++i];
+        else { std::cerr << "Unknown arg: " << a << "\n"; print_usage(argv[0]); return 1; }
+    }
+    if (model0_path.empty() || model1_path.empty() || n_deals <= 0) {
+        std::cerr << "Error: --model0, --model1, and --deals (>0) are required\n\n";
+        print_usage(argv[0]); return 1;
+    }
+
+    torch::Device device = torch::kCPU;
+    if      (device_str == "auto")  device = torch::cuda::is_available() ? torch::kCUDA : torch::kCPU;
+    else if (device_str == "cuda")  device = torch::kCUDA;
+    else if (device_str != "cpu") { std::cerr << "Unknown device: " << device_str << "\n"; return 1; }
+    std::cout << "Device: " << (device == torch::kCUDA ? "cuda" : "cpu") << "\n";
+
+    std::cout << "Loading models...\n";
+    torch::jit::Module model0 = torch::jit::load(model0_path);
+    torch::jit::Module model1 = torch::jit::load(model1_path);
+    model0.eval(); model0.to(device);
+    model1.eval(); model1.to(device);
+    std::cout << "  model0: " << model0_path << "\n"
+              << "  model1: " << model1_path << "\n\n";
+
+    long total_games = 2L * n_deals;
+    std::cout << "=== NN Eval Match: model0 vs model1 ===\n"
+              << "Deals: " << n_deals << "  |  Games: " << total_games << "\n"
+              << "Seed: " << seed << "\n\n";
+
+    long m0_wins = 0;
+    long p0_sweep = 0, split_count = 0, p1_sweep = 0;
+
+    auto t_start = std::chrono::high_resolution_clock::now();
+
+    for (int deal = 0; deal < n_deals; ++deal) {
+        unsigned int unit_seed = seed + (unsigned int)deal;
+        int deal_m0_wins = 0;
+
+        // Game 1: model0=p0, model1=p1
+        {
+            std::mt19937 rng(unit_seed);
+            NNGameRunner runner(make_nn_policy(model0, device),
+                                make_nn_policy(model1, device));
+            if (runner.run_game(rng).winner == 0) ++deal_m0_wins;
+        }
+        // Game 2: seats swapped (same seed = same deal)
+        {
+            std::mt19937 rng(unit_seed);
+            NNGameRunner runner(make_nn_policy(model1, device),
+                                make_nn_policy(model0, device));
+            if (runner.run_game(rng).winner == 1) ++deal_m0_wins;
+        }
+
+        m0_wins += deal_m0_wins;
+        if      (deal_m0_wins == 2) ++p0_sweep;
+        else if (deal_m0_wins == 0) ++p1_sweep;
+        else                        ++split_count;
+
+        if ((deal + 1) % 50 == 0 || deal + 1 == n_deals) {
+            auto now = std::chrono::high_resolution_clock::now();
+            double elapsed = std::chrono::duration<double>(now - t_start).count();
+            double rate = elapsed > 0 ? 2.0 * (deal + 1) / elapsed : 0;
+            std::fprintf(stderr, "\rDeals: %d/%d  |  %.0f games/s   ",
+                         deal + 1, n_deals, rate);
+            std::fflush(stderr);
+        }
+    }
+    std::fprintf(stderr, "\n");
+
+    auto t_end = std::chrono::high_resolution_clock::now();
+    long long elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        t_end - t_start).count();
+
+    double p_hat = (double)m0_wins / (double)total_games;
+    WilsonCI ci  = wilson_ci(p_hat, total_games);
+
+    std::cout << "Model0 wins: " << m0_wins << " / " << total_games
+              << std::fixed;
+    std::cout.precision(2);
+    std::cout << " (" << 100.0 * p_hat << "%)\n"
+              << "95% Wilson CI: [" << 100.0 * ci.lo << "%, " << 100.0 * ci.hi << "%]\n";
+
+    if      (ci.lo > 0.50) std::cout << "Result: model0 is significantly better (CI excludes 50%)\n";
+    else if (ci.hi < 0.50) std::cout << "Result: model1 is significantly better (CI excludes 50%)\n";
+    else                   std::cout << "Result: no significant difference (CI includes 50%)\n";
+
+    double inv = 1.0 / n_deals;
+    std::cout << "Deals: model0_sweep=" << p0_sweep << " split=" << split_count
+              << " model1_sweep=" << p1_sweep << "\n";
+    std::cout.precision(2);
+    std::cout << "Deals: model0 2-0: " << p0_sweep
+              << " (" << 100.0 * p0_sweep * inv << "%)  split 1-1: " << split_count
+              << " (" << 100.0 * split_count * inv << "%)  model1 2-0: " << p1_sweep
+              << " (" << 100.0 * p1_sweep * inv << "%)\n";
+
+    long n_decisive = p0_sweep + p1_sweep;
+    if (n_decisive > 0) {
+        double p_dec = (double)p0_sweep / (double)n_decisive;
+        WilsonCI ci_dec = wilson_ci(p_dec, n_decisive);
+        std::cout << "Among decisive: model0 " << p0_sweep << " / " << n_decisive
+                  << " (" << 100.0 * p_dec << "%)  CI: ["
+                  << 100.0 * ci_dec.lo << "%, " << 100.0 * ci_dec.hi << "%]\n";
+        if      (ci_dec.lo > 0.50) std::cout << "Result (decisive): model0 sweeps more\n";
+        else if (ci_dec.hi < 0.50) std::cout << "Result (decisive): model1 sweeps more\n";
+        else                        std::cout << "Result (decisive): no significant difference\n";
+    }
+
+    std::cout << "Elapsed: " << format_elapsed(elapsed_ms)
+              << "  (" << (long long)(elapsed_ms > 0 ? 1000.0*total_games/elapsed_ms : 0)
+              << " games/s)\n\n";
+    return 0;
+}

--- a/src/datagen/eval_nn_match.cpp
+++ b/src/datagen/eval_nn_match.cpp
@@ -1,159 +1,58 @@
 // eval_nn_match: head-to-head evaluation between two TorchScript NN models.
 //
-// Uses paired deals (same shuffle, seats swapped) so card luck cancels.
-// Single-threaded; CPU inference is fast enough for ~1k deals (<30s).
+// Pool-based batched NN inference: all 2*n_deals games run concurrently.
+// Each batch round advances every game past tablebase/forced moves, then
+// does one batched forward pass for model0 positions and one for model1
+// positions. GPU utilization is ~2000x better than serial per-position inference.
 //
 // Usage:
-//   eval_nn_match --model0 PATH --model1 PATH --deals N [--seed S]
-//                 [--device auto|cpu|cuda]
+//   eval_nn_match --model0 PATH --model1 PATH --deals N [--seed S] [--device D]
 
-#include "nn_game_runner.h"
-#include "nn_encode.h"
+#include "eval_helpers.h"
 
-#include "game.h"
-#include "hint_table.h"
-#include "util.h"
-
-#include <torch/script.h>
 #include <torch/cuda.h>
+#include <torch/script.h>
 
-#include <algorithm>
-#include <array>
 #include <chrono>
-#include <cmath>
 #include <cstdio>
 #include <iostream>
 #include <random>
 #include <string>
+#include <vector>
 
 // ============================================================================
-// Wilson score 95% confidence interval for a proportion
+// Eval slot: one active game
 // ============================================================================
 
-struct WilsonCI { double lo, hi; };
+struct EvalSlot {
+    Game game;
+    int  deal_id;
+    int  m0_player;          // seat (0 or 1) occupied by model0
+    std::vector<int> legal;  // cached legal moves when NN decision is needed
+    bool done{false};
+    int  winner{-1};
+};
 
-static WilsonCI wilson_ci(double p_hat, long n, double z = 1.96) {
-    double z2 = z * z, n_inv = 1.0 / (double)n;
-    double center = (p_hat + z2 * n_inv / 2.0) / (1.0 + z2 * n_inv);
-    double half = z * std::sqrt(p_hat * (1.0 - p_hat) * n_inv + z2 * n_inv * n_inv / 4.0) /
-                  (1.0 + z2 * n_inv);
-    return {center - half, center + half};
+// Advance slot past tablebase/forced moves until game over or NN decision needed.
+// Does NOT call any NN; just handles deterministic cases.
+static void advance_to_decision(EvalSlot& slot) {
+    while (!slot.game.is_over()) {
+        int cp = slot.game.current_player();
+        slot.legal = slot.game.get_legal_moves();
+        int tb = tablebase_move_id(slot.game, cp, slot.legal);
+        if (tb >= 0) { slot.game.apply_move(tb); continue; }
+        if ((int)slot.legal.size() == 1) { slot.game.apply_move(slot.legal[0]); continue; }
+        return;  // NN decision needed
+    }
 }
 
 // ============================================================================
-// NN PolicyFn factory
-//
-// Encodes all K legal moves for the current position, runs a single batched
-// forward pass, and returns the move with highest expected value
-// w = p_trick * v_init + (1 - p_trick) * v_no_init.
+// Reporting
 // ============================================================================
-
-static PolicyFn make_nn_policy(torch::jit::Module& model, torch::Device device) {
-    return [&model, device](const Game& game, int player_num,
-                             const std::vector<int>& legal_moves) -> int {
-        const int K = (int)legal_moves.size();
-
-        HandBits hb      = game.player_hand_bits(player_num);
-        auto discard     = game.discard_pile();
-        auto hand_counts = hand_bits_to_counts(hb);
-        int  opp_count   = game.get_player_hand_size(1 - player_num);
-
-        // Opponent max possible counts + HandBits for respond check
-        std::array<int,13> opp_counts{};
-        HandBits opp_bits{};
-        for (int r = 0; r < 13; ++r) {
-            int hand_r = ((hb.at1>>r)&1)+((hb.at2>>r)&1)+((hb.at3>>r)&1)+((hb.at4>>r)&1);
-            int om = std::max(0, max_cards_in_deck_for_rank(r) - hand_r - discard[r]);
-            opp_counts[r] = om;
-            if (om >= 1) opp_bits.at1 |= static_cast<uint16_t>(1u << r);
-            if (om >= 2) opp_bits.at2 |= static_cast<uint16_t>(1u << r);
-            if (om >= 3) opp_bits.at3 |= static_cast<uint16_t>(1u << r);
-            if (om >= 4) opp_bits.at4 |= static_cast<uint16_t>(1u << r);
-        }
-
-        auto float_opts = torch::TensorOptions().dtype(torch::kFloat32);
-        auto bool_opts  = torch::TensorOptions().dtype(torch::kBool);
-        torch::Tensor t_hand = torch::zeros({K, ENCODING_DIM}, float_opts);
-        torch::Tensor t_opp  = torch::zeros({K, ENCODING_DIM}, float_opts);
-        torch::Tensor t_move = torch::zeros({K, ENCODING_DIM}, float_opts);
-        torch::Tensor t_hint = torch::zeros({K}, float_opts);
-        torch::Tensor t_flag = torch::zeros({K}, bool_opts);
-        torch::Tensor t_pass = torch::zeros({K}, bool_opts);
-
-        float* h_hand = t_hand.data_ptr<float>();
-        float* h_opp  = t_opp.data_ptr<float>();
-        float* h_move = t_move.data_ptr<float>();
-        float* h_hint = t_hint.data_ptr<float>();
-        bool*  h_flag = t_flag.data_ptr<bool>();
-        bool*  h_pass = t_pass.data_ptr<bool>();
-
-        for (int i = 0; i < K; ++i) {
-            int mid = legal_moves[i];
-            bool is_pass_move = (mid == kPASS);
-
-            std::array<int,13> mc{};
-            if (!is_pass_move)
-                for (int r = 0; r < 13; ++r) mc[r] = MOVE_TO_CARDS[mid][r];
-
-            // Hand after playing this move (model input is post-move hand)
-            std::array<int,13> hand_after{};
-            for (int r = 0; r < 13; ++r) hand_after[r] = hand_counts[r] - mc[r];
-
-            encode_exact(hand_after,  h_hand + i * ENCODING_DIM);
-            encode_thermo(opp_counts, h_opp  + i * ENCODING_DIM);
-            encode_exact(mc,          h_move + i * ENCODING_DIM);
-
-            bool flag_val = !is_pass_move && !opponent_can_respond(mid, opp_bits, opp_count);
-            h_hint[i] = is_pass_move ? 0.0f : (flag_val ? 1.0f : (1.0f - kHintTable[mid]));
-            h_flag[i] = flag_val;
-            h_pass[i] = is_pass_move;
-        }
-
-        torch::NoGradGuard no_grad;
-        auto out = model.forward({
-            t_hand.to(device), t_opp.to(device), t_move.to(device),
-            t_hint.to(device), t_flag.to(device), t_pass.to(device)
-        }).toTuple();
-
-        auto vi  = out->elements()[0].toTensor().to(torch::kCPU);
-        auto vn  = out->elements()[1].toTensor().to(torch::kCPU);
-        auto pt  = out->elements()[2].toTensor().to(torch::kCPU);
-        auto* vi_p = vi.data_ptr<float>();
-        auto* vn_p = vn.data_ptr<float>();
-        auto* pt_p = pt.data_ptr<float>();
-
-        int   best   = 0;
-        float best_w = -1.0f;
-        for (int i = 0; i < K; ++i) {
-            float w = pt_p[i] * vi_p[i] + (1.0f - pt_p[i]) * vn_p[i];
-            if (w > best_w) { best_w = w; best = i; }
-        }
-        return legal_moves[best];
-    };
-}
-
-// ============================================================================
-// Reporting helpers (shared with eval_match style)
-// ============================================================================
-
-static std::string format_elapsed(long long ms) {
-    if (ms < 1000) { char b[32]; std::snprintf(b, sizeof(b), "%lld ms", ms); return b; }
-    double s = ms / 1000.0;
-    char b[64];
-    if (s < 60) std::snprintf(b, sizeof(b), "%.1f s", s);
-    else        std::snprintf(b, sizeof(b), "%dm %ds", (int)(s/60), (int)s%60);
-    return b;
-}
 
 static void print_usage(const char* prog) {
     std::cout << "Usage: " << prog
-              << " --model0 PATH --model1 PATH --deals N [--seed S] [--device auto|cpu|cuda]\n"
-              << "Options:\n"
-              << "  --model0 PATH    Model A (TorchScript .pt)\n"
-              << "  --model1 PATH    Model B (TorchScript .pt)\n"
-              << "  --deals N        Paired deals; total games = 2*N\n"
-              << "  --seed S         RNG seed (default: random)\n"
-              << "  --device D       auto|cpu|cuda (default: auto)\n";
+              << " --model0 PATH --model1 PATH --deals N [--seed S] [--device auto|cpu|cuda]\n";
 }
 
 // ============================================================================
@@ -167,12 +66,12 @@ int main(int argc, char** argv) {
 
     for (int i = 1; i < argc; ++i) {
         std::string a = argv[i];
-        if      (a == "--help"   || a == "-h")  { print_usage(argv[0]); return 0; }
-        else if (a == "--model0" && i+1 < argc)  model0_path = argv[++i];
-        else if (a == "--model1" && i+1 < argc)  model1_path = argv[++i];
-        else if (a == "--deals"  && i+1 < argc)  n_deals     = std::stoi(argv[++i]);
-        else if (a == "--seed"   && i+1 < argc)  seed        = (unsigned)std::stoul(argv[++i]);
-        else if (a == "--device" && i+1 < argc)  device_str  = argv[++i];
+        if      (a == "--help"   || a == "-h") { print_usage(argv[0]); return 0; }
+        else if (a == "--model0" && i+1 < argc) model0_path = argv[++i];
+        else if (a == "--model1" && i+1 < argc) model1_path = argv[++i];
+        else if (a == "--deals"  && i+1 < argc) n_deals     = std::stoi(argv[++i]);
+        else if (a == "--seed"   && i+1 < argc) seed        = (unsigned)std::stoul(argv[++i]);
+        else if (a == "--device" && i+1 < argc) device_str  = argv[++i];
         else { std::cerr << "Unknown arg: " << a << "\n"; print_usage(argv[0]); return 1; }
     }
     if (model0_path.empty() || model1_path.empty() || n_deals <= 0) {
@@ -181,8 +80,8 @@ int main(int argc, char** argv) {
     }
 
     torch::Device device = torch::kCPU;
-    if      (device_str == "auto")  device = torch::cuda::is_available() ? torch::kCUDA : torch::kCPU;
-    else if (device_str == "cuda")  device = torch::kCUDA;
+    if      (device_str == "auto") device = torch::cuda::is_available() ? torch::kCUDA : torch::kCPU;
+    else if (device_str == "cuda") device = torch::kCUDA;
     else if (device_str != "cpu") { std::cerr << "Unknown device: " << device_str << "\n"; return 1; }
     std::cout << "Device: " << (device == torch::kCUDA ? "cuda" : "cpu") << "\n";
 
@@ -199,55 +98,91 @@ int main(int argc, char** argv) {
               << "Deals: " << n_deals << "  |  Games: " << total_games << "\n"
               << "Seed: " << seed << "\n\n";
 
-    long m0_wins = 0;
-    long p0_sweep = 0, split_count = 0, p1_sweep = 0;
+    // ── Initialise pool (2 games per deal, seats swapped) ────────────────────
+    std::vector<EvalSlot> pool(2 * n_deals);
+    std::vector<int> deal_m0_wins(n_deals, 0);
 
-    auto t_start = std::chrono::high_resolution_clock::now();
-
-    for (int deal = 0; deal < n_deals; ++deal) {
-        unsigned int unit_seed = seed + (unsigned int)deal;
-        int deal_m0_wins = 0;
-
-        // Game 1: model0=p0, model1=p1
-        {
-            std::mt19937 rng(unit_seed);
-            NNGameRunner runner(make_nn_policy(model0, device),
-                                make_nn_policy(model1, device));
-            if (runner.run_game(rng).winner == 0) ++deal_m0_wins;
-        }
-        // Game 2: seats swapped (same seed = same deal)
-        {
-            std::mt19937 rng(unit_seed);
-            NNGameRunner runner(make_nn_policy(model1, device),
-                                make_nn_policy(model0, device));
-            if (runner.run_game(rng).winner == 1) ++deal_m0_wins;
-        }
-
-        m0_wins += deal_m0_wins;
-        if      (deal_m0_wins == 2) ++p0_sweep;
-        else if (deal_m0_wins == 0) ++p1_sweep;
-        else                        ++split_count;
-
-        if ((deal + 1) % 50 == 0 || deal + 1 == n_deals) {
-            auto now = std::chrono::high_resolution_clock::now();
-            double elapsed = std::chrono::duration<double>(now - t_start).count();
-            double rate = elapsed > 0 ? 2.0 * (deal + 1) / elapsed : 0;
-            std::fprintf(stderr, "\rDeals: %d/%d  |  %.0f games/s   ",
-                         deal + 1, n_deals, rate);
-            std::fflush(stderr);
+    for (int d = 0; d < n_deals; ++d) {
+        for (int seat = 0; seat < 2; ++seat) {
+            EvalSlot& sl = pool[2*d + seat];
+            std::mt19937 rng(seed + (unsigned)d);
+            sl.game.shuffle_deal(rng);
+            sl.deal_id   = d;
+            sl.m0_player = seat;  // seat 0: m0 plays player 0; seat 1: m0 plays player 1
         }
     }
-    std::fprintf(stderr, "\n");
+
+    auto t_start = std::chrono::high_resolution_clock::now();
+    int n_done = 0;
+
+    // ── Pool-based eval loop ──────────────────────────────────────────────────
+    while (n_done < (int)pool.size()) {
+
+        // 1. Advance all active slots to decision points.
+        std::vector<int> m0_idx, m1_idx;  // slot indices where m0 / m1 must decide
+
+        for (int si = 0; si < (int)pool.size(); ++si) {
+            EvalSlot& sl = pool[si];
+            if (sl.done) continue;
+
+            advance_to_decision(sl);
+
+            if (sl.game.is_over()) {
+                sl.done   = true;
+                sl.winner = sl.game.get_winner();
+                ++n_done;
+                if (sl.winner == sl.m0_player) ++deal_m0_wins[sl.deal_id];
+            } else {
+                int cp = sl.game.current_player();
+                if (cp == sl.m0_player) m0_idx.push_back(si);
+                else                    m1_idx.push_back(si);
+            }
+        }
+
+        if (n_done == (int)pool.size()) break;
+
+        // 2. Batch forward pass for model0.
+        if (!m0_idx.empty()) {
+            std::vector<NNPosition> pos;
+            pos.reserve(m0_idx.size());
+            for (int si : m0_idx)
+                pos.emplace_back(&pool[si].game, pool[si].game.current_player(), &pool[si].legal);
+            auto best = batch_nn_select(model0, device, pos);
+            for (int i = 0; i < (int)m0_idx.size(); ++i)
+                pool[m0_idx[i]].game.apply_move(pool[m0_idx[i]].legal[best[i]]);
+        }
+
+        // 3. Batch forward pass for model1.
+        if (!m1_idx.empty()) {
+            std::vector<NNPosition> pos;
+            pos.reserve(m1_idx.size());
+            for (int si : m1_idx)
+                pos.emplace_back(&pool[si].game, pool[si].game.current_player(), &pool[si].legal);
+            auto best = batch_nn_select(model1, device, pos);
+            for (int i = 0; i < (int)m1_idx.size(); ++i)
+                pool[m1_idx[i]].game.apply_move(pool[m1_idx[i]].legal[best[i]]);
+        }
+    }
 
     auto t_end = std::chrono::high_resolution_clock::now();
     long long elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
         t_end - t_start).count();
 
+    // ── Aggregate results ─────────────────────────────────────────────────────
+    long m0_wins = 0;
+    long p0_sweep = 0, split_count = 0, p1_sweep = 0;
+    for (int d = 0; d < n_deals; ++d) {
+        int w = deal_m0_wins[d];
+        m0_wins += w;
+        if      (w == 2) ++p0_sweep;
+        else if (w == 0) ++p1_sweep;
+        else             ++split_count;
+    }
+
     double p_hat = (double)m0_wins / (double)total_games;
     WilsonCI ci  = wilson_ci(p_hat, total_games);
 
-    std::cout << "Model0 wins: " << m0_wins << " / " << total_games
-              << std::fixed;
+    std::cout << "Model0 wins: " << m0_wins << " / " << total_games << std::fixed;
     std::cout.precision(2);
     std::cout << " (" << 100.0 * p_hat << "%)\n"
               << "95% Wilson CI: [" << 100.0 * ci.lo << "%, " << 100.0 * ci.hi << "%]\n";
@@ -257,12 +192,9 @@ int main(int argc, char** argv) {
     else                   std::cout << "Result: no significant difference (CI includes 50%)\n";
 
     double inv = 1.0 / n_deals;
-    std::cout << "Deals: model0_sweep=" << p0_sweep << " split=" << split_count
-              << " model1_sweep=" << p1_sweep << "\n";
-    std::cout.precision(2);
-    std::cout << "Deals: model0 2-0: " << p0_sweep
-              << " (" << 100.0 * p0_sweep * inv << "%)  split 1-1: " << split_count
-              << " (" << 100.0 * split_count * inv << "%)  model1 2-0: " << p1_sweep
+    std::cout << "Deals: WW=" << p0_sweep
+              << " (" << 100.0 * p0_sweep * inv << "%)  split=" << split_count
+              << " (" << 100.0 * split_count * inv << "%)  LL=" << p1_sweep
               << " (" << 100.0 * p1_sweep * inv << "%)\n";
 
     long n_decisive = p0_sweep + p1_sweep;
@@ -272,9 +204,6 @@ int main(int argc, char** argv) {
         std::cout << "Among decisive: model0 " << p0_sweep << " / " << n_decisive
                   << " (" << 100.0 * p_dec << "%)  CI: ["
                   << 100.0 * ci_dec.lo << "%, " << 100.0 * ci_dec.hi << "%]\n";
-        if      (ci_dec.lo > 0.50) std::cout << "Result (decisive): model0 sweeps more\n";
-        else if (ci_dec.hi < 0.50) std::cout << "Result (decisive): model1 sweeps more\n";
-        else                        std::cout << "Result (decisive): no significant difference\n";
     }
 
     std::cout << "Elapsed: " << format_elapsed(elapsed_ms)

--- a/src/datagen/eval_nn_vs_classic.cpp
+++ b/src/datagen/eval_nn_vs_classic.cpp
@@ -1,0 +1,304 @@
+// eval_nn_vs_classic: head-to-head evaluation, NN model vs classic player.
+//
+// Uses paired deals (same shuffle, seats swapped) and reports Wilson 95% CI.
+// Single-threaded; use --deals 500-1000 for reliable estimates.
+//
+// Usage:
+//   eval_nn_vs_classic --model PATH --vs PLAYER [--vs-param F]
+//                      --deals N [--seed S] [--device auto|cpu|cuda]
+
+// LibTorch must come first to avoid macro conflicts.
+#include <torch/script.h>
+#include <torch/cuda.h>
+
+#include "nn_encode.h"
+
+#include "game_simulator.h"
+#include "hint_table.h"
+#include "player_factory_registry.h"
+#include "util.h"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <string>
+
+// ============================================================================
+// NNPlayer: wraps a TorchScript model using PartialGame for feature encoding
+// ============================================================================
+
+class NNPlayer : public Player {
+public:
+    NNPlayer(torch::jit::Module& model, torch::Device device)
+        : model_(model), device_(device) {}
+
+protected:
+    Move select_move_impl() override {
+        auto legal      = game_.get_legal_moves();
+        const int K     = (int)legal.size();
+        auto player_hand = game_.player_hand();
+        auto discard    = game_.discard_pile();
+        int  opp_count  = game_.opponent_hand_size();
+
+        std::array<int,13> opp_counts{};
+        HandBits opp_bits{};
+        for (int r = 0; r < 13; ++r) {
+            int om = std::max(0, max_cards_in_deck_for_rank(r) - player_hand[r] - discard[r]);
+            opp_counts[r] = om;
+            if (om >= 1) opp_bits.at1 |= static_cast<uint16_t>(1u << r);
+            if (om >= 2) opp_bits.at2 |= static_cast<uint16_t>(1u << r);
+            if (om >= 3) opp_bits.at3 |= static_cast<uint16_t>(1u << r);
+            if (om >= 4) opp_bits.at4 |= static_cast<uint16_t>(1u << r);
+        }
+
+        auto float_opts = torch::TensorOptions().dtype(torch::kFloat32);
+        auto bool_opts  = torch::TensorOptions().dtype(torch::kBool);
+        torch::Tensor t_hand = torch::zeros({K, ENCODING_DIM}, float_opts);
+        torch::Tensor t_opp  = torch::zeros({K, ENCODING_DIM}, float_opts);
+        torch::Tensor t_move = torch::zeros({K, ENCODING_DIM}, float_opts);
+        torch::Tensor t_hint = torch::zeros({K}, float_opts);
+        torch::Tensor t_flag = torch::zeros({K}, bool_opts);
+        torch::Tensor t_pass = torch::zeros({K}, bool_opts);
+
+        float* h_hand = t_hand.data_ptr<float>();
+        float* h_opp  = t_opp.data_ptr<float>();
+        float* h_move = t_move.data_ptr<float>();
+        float* h_hint = t_hint.data_ptr<float>();
+        bool*  h_flag = t_flag.data_ptr<bool>();
+        bool*  h_pass = t_pass.data_ptr<bool>();
+
+        for (int i = 0; i < K; ++i) {
+            int mid = legal[i];
+            bool is_pass_move = (mid == kPASS);
+            std::array<int,13> mc{};
+            if (!is_pass_move)
+                for (int r = 0; r < 13; ++r) mc[r] = MOVE_TO_CARDS[mid][r];
+            std::array<int,13> hand_after{};
+            for (int r = 0; r < 13; ++r) hand_after[r] = player_hand[r] - mc[r];
+
+            encode_exact(hand_after,  h_hand + i * ENCODING_DIM);
+            encode_thermo(opp_counts, h_opp  + i * ENCODING_DIM);
+            encode_exact(mc,          h_move + i * ENCODING_DIM);
+
+            bool flag_val = !is_pass_move && !opponent_can_respond(mid, opp_bits, opp_count);
+            h_hint[i] = is_pass_move ? 0.0f : (flag_val ? 1.0f : (1.0f - kHintTable[mid]));
+            h_flag[i] = flag_val;
+            h_pass[i] = is_pass_move;
+        }
+
+        torch::NoGradGuard no_grad;
+        auto out = model_.forward({
+            t_hand.to(device_), t_opp.to(device_), t_move.to(device_),
+            t_hint.to(device_), t_flag.to(device_), t_pass.to(device_)
+        }).toTuple();
+
+        auto vi  = out->elements()[0].toTensor().to(torch::kCPU);
+        auto vn  = out->elements()[1].toTensor().to(torch::kCPU);
+        auto pt  = out->elements()[2].toTensor().to(torch::kCPU);
+        auto* vi_p = vi.data_ptr<float>();
+        auto* vn_p = vn.data_ptr<float>();
+        auto* pt_p = pt.data_ptr<float>();
+
+        int   best   = 0;
+        float best_w = -1.0f;
+        for (int i = 0; i < K; ++i) {
+            float w = pt_p[i] * vi_p[i] + (1.0f - pt_p[i]) * vn_p[i];
+            if (w > best_w) { best_w = w; best = i; }
+        }
+        return Move(legal[best]);
+    }
+
+private:
+    torch::jit::Module& model_;
+    torch::Device device_;
+};
+
+class NNPlayerFactory : public PlayerFactory {
+public:
+    NNPlayerFactory(torch::jit::Module& model, torch::Device device)
+        : model_(model), device_(device) {}
+
+    std::unique_ptr<Player> create_player() override {
+        return std::make_unique<NNPlayer>(model_, device_);
+    }
+
+private:
+    torch::jit::Module& model_;
+    torch::Device device_;
+};
+
+// ============================================================================
+// Wilson score 95% CI
+// ============================================================================
+
+struct WilsonCI { double lo, hi; };
+static WilsonCI wilson_ci(double p_hat, long n, double z = 1.96) {
+    double z2 = z*z, n_inv = 1.0/(double)n;
+    double center = (p_hat + z2*n_inv/2.0) / (1.0 + z2*n_inv);
+    double half = z * std::sqrt(p_hat*(1.0-p_hat)*n_inv + z2*n_inv*n_inv/4.0) /
+                  (1.0 + z2*n_inv);
+    return {center - half, center + half};
+}
+
+static std::string format_elapsed(long long ms) {
+    if (ms < 1000) { char b[32]; std::snprintf(b, sizeof(b), "%lld ms", ms); return b; }
+    double s = ms/1000.0; char b[64];
+    if (s < 60) std::snprintf(b, sizeof(b), "%.1f s", s);
+    else        std::snprintf(b, sizeof(b), "%dm %ds", (int)(s/60), (int)s%60);
+    return b;
+}
+
+static void print_usage(const char* prog) {
+    std::cout << "Usage: " << prog
+              << " --model PATH --vs PLAYER [--vs-param F] --deals N [--seed S] [--device auto|cpu|cuda]\n"
+              << "Options:\n"
+              << "  --model PATH     NN model (TorchScript .pt); plays as model0\n"
+              << "  --vs PLAYER      Classic opponent: random, greedy, pimc, etc.\n"
+              << "  --vs-param F     Parameter for classic player (default: 0.0)\n"
+              << "  --deals N        Paired deals; total games = 2*N\n"
+              << "  --seed S         RNG seed (default: random)\n"
+              << "  --device D       auto|cpu|cuda (default: auto)\n";
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char** argv) {
+    std::string model_path, vs_name, device_str = "auto";
+    double vs_param = 0.0;
+    int n_deals = 0;
+    unsigned int seed = std::random_device{}();
+
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if      (a == "--help"     || a == "-h")  { print_usage(argv[0]); return 0; }
+        else if (a == "--model"    && i+1 < argc)  model_path = argv[++i];
+        else if (a == "--vs"       && i+1 < argc)  vs_name    = argv[++i];
+        else if (a == "--vs-param" && i+1 < argc)  vs_param   = std::stod(argv[++i]);
+        else if (a == "--deals"    && i+1 < argc)  n_deals    = std::stoi(argv[++i]);
+        else if (a == "--seed"     && i+1 < argc)  seed       = (unsigned)std::stoul(argv[++i]);
+        else if (a == "--device"   && i+1 < argc)  device_str = argv[++i];
+        else { std::cerr << "Unknown arg: " << a << "\n"; print_usage(argv[0]); return 1; }
+    }
+    if (model_path.empty() || vs_name.empty() || n_deals <= 0) {
+        std::cerr << "Error: --model, --vs, and --deals (>0) are required\n\n";
+        print_usage(argv[0]); return 1;
+    }
+
+    torch::Device device = torch::kCPU;
+    if      (device_str == "auto")  device = torch::cuda::is_available() ? torch::kCUDA : torch::kCPU;
+    else if (device_str == "cuda")  device = torch::kCUDA;
+    else if (device_str != "cpu") { std::cerr << "Unknown device: " << device_str << "\n"; return 1; }
+    std::cout << "Device: " << (device == torch::kCUDA ? "cuda" : "cpu") << "\n";
+
+    std::cout << "Loading model: " << model_path << "\n";
+    torch::jit::Module model = torch::jit::load(model_path);
+    model.eval(); model.to(device);
+
+    NNPlayerFactory nn_factory(model, device);
+    auto classic_factory = make_player_factory(vs_name, vs_param, seed);
+    if (!classic_factory) {
+        std::cerr << "Unknown player: " << vs_name << "\n"; return 1;
+    }
+
+    std::string vs_label = vs_name;
+    if (vs_param != 0.0) {
+        char buf[64]; std::snprintf(buf, sizeof(buf), "%s(%.4g)", vs_name.c_str(), vs_param);
+        vs_label = buf;
+    }
+
+    long total_games = 2L * n_deals;
+    std::cout << "\n=== NN vs Classic: model0 vs " << vs_label << " ===\n"
+              << "Deals: " << n_deals << "  |  Games: " << total_games << "\n"
+              << "Seed: " << seed << "\n\n";
+
+    long nn_wins = 0;
+    long p0_sweep = 0, split_count = 0, p1_sweep = 0;
+
+    auto t_start = std::chrono::high_resolution_clock::now();
+
+    for (int deal = 0; deal < n_deals; ++deal) {
+        unsigned int unit_seed = seed + (unsigned int)deal;
+        int deal_nn_wins = 0;
+
+        // Game 1: NN=p0, classic=p1
+        {
+            std::mt19937 rng(unit_seed);
+            auto p0 = nn_factory.create_player();
+            auto p1 = classic_factory->create_player();
+            GameSimulator sim(std::move(p0), std::move(p1), rng);
+            if (sim.run().game().get_winner() == 0) ++deal_nn_wins;
+        }
+        // Game 2: classic=p0, NN=p1 (same seed = same deal)
+        {
+            std::mt19937 rng(unit_seed);
+            auto p0 = classic_factory->create_player();
+            auto p1 = nn_factory.create_player();
+            GameSimulator sim(std::move(p0), std::move(p1), rng);
+            if (sim.run().game().get_winner() == 1) ++deal_nn_wins;
+        }
+
+        nn_wins += deal_nn_wins;
+        if      (deal_nn_wins == 2) ++p0_sweep;
+        else if (deal_nn_wins == 0) ++p1_sweep;
+        else                        ++split_count;
+
+        if ((deal + 1) % 50 == 0 || deal + 1 == n_deals) {
+            auto now = std::chrono::high_resolution_clock::now();
+            double elapsed = std::chrono::duration<double>(now - t_start).count();
+            double rate = elapsed > 0 ? 2.0 * (deal + 1) / elapsed : 0;
+            std::fprintf(stderr, "\rDeals: %d/%d  |  %.0f games/s   ",
+                         deal + 1, n_deals, rate);
+            std::fflush(stderr);
+        }
+    }
+    std::fprintf(stderr, "\n");
+
+    auto t_end = std::chrono::high_resolution_clock::now();
+    long long elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        t_end - t_start).count();
+
+    double p_hat = (double)nn_wins / (double)total_games;
+    WilsonCI ci  = wilson_ci(p_hat, total_games);
+
+    std::cout << "NN wins: " << nn_wins << " / " << total_games << std::fixed;
+    std::cout.precision(2);
+    std::cout << " (" << 100.0 * p_hat << "%)\n"
+              << "95% Wilson CI: [" << 100.0 * ci.lo << "%, " << 100.0 * ci.hi << "%]\n";
+
+    if      (ci.lo > 0.50) std::cout << "Result: NN is significantly better (CI excludes 50%)\n";
+    else if (ci.hi < 0.50) std::cout << "Result: " << vs_label << " is significantly better (CI excludes 50%)\n";
+    else                   std::cout << "Result: no significant difference (CI includes 50%)\n";
+
+    double inv = 1.0 / n_deals;
+    std::cout << "Deals: nn_sweep=" << p0_sweep << " split=" << split_count
+              << " classic_sweep=" << p1_sweep << "\n";
+    std::cout.precision(2);
+    std::cout << "Deals: nn 2-0: " << p0_sweep
+              << " (" << 100.0 * p0_sweep * inv << "%)  split 1-1: " << split_count
+              << " (" << 100.0 * split_count * inv << "%)  classic 2-0: " << p1_sweep
+              << " (" << 100.0 * p1_sweep * inv << "%)\n";
+
+    long n_decisive = p0_sweep + p1_sweep;
+    if (n_decisive > 0) {
+        double p_dec = (double)p0_sweep / (double)n_decisive;
+        WilsonCI ci_dec = wilson_ci(p_dec, n_decisive);
+        std::cout << "Among decisive: nn " << p0_sweep << " / " << n_decisive
+                  << " (" << 100.0 * p_dec << "%)  CI: ["
+                  << 100.0 * ci_dec.lo << "%, " << 100.0 * ci_dec.hi << "%]\n";
+        if      (ci_dec.lo > 0.50) std::cout << "Result (decisive): NN sweeps more\n";
+        else if (ci_dec.hi < 0.50) std::cout << "Result (decisive): " << vs_label << " sweeps more\n";
+        else                        std::cout << "Result (decisive): no significant difference\n";
+    }
+
+    std::cout << "Elapsed: " << format_elapsed(elapsed_ms)
+              << "  (" << (long long)(elapsed_ms > 0 ? 1000.0*total_games/elapsed_ms : 0)
+              << " games/s)\n\n";
+    return 0;
+}

--- a/src/datagen/eval_nn_vs_classic.cpp
+++ b/src/datagen/eval_nn_vs_classic.cpp
@@ -1,165 +1,154 @@
 // eval_nn_vs_classic: head-to-head evaluation, NN model vs classic player.
 //
-// Uses paired deals (same shuffle, seats swapped) and reports Wilson 95% CI.
-// Single-threaded; use --deals 500-1000 for reliable estimates.
+// Pool-based batched NN inference: all 2*n_deals games run concurrently.
+// Classic (random/greedy) moves are applied inline per slot; NN decisions
+// are batched across all active slots into a single forward pass per round.
+//
+// For PIMC: a per-slot Player object keeps the classic player's PartialGame
+// in sync. PIMC moves are applied sequentially (CPU-bound) between NN batches.
 //
 // Usage:
 //   eval_nn_vs_classic --model PATH --vs PLAYER [--vs-param F]
 //                      --deals N [--seed S] [--device auto|cpu|cuda]
 
 // LibTorch must come first to avoid macro conflicts.
-#include <torch/script.h>
 #include <torch/cuda.h>
+#include <torch/script.h>
 
-#include "nn_encode.h"
+#include "eval_helpers.h"
 
-#include "game_simulator.h"
-#include "hint_table.h"
+#include "greedy/greedy_player.h"
+#include "player.h"
 #include "player_factory_registry.h"
-#include "util.h"
 
-#include <algorithm>
-#include <array>
 #include <chrono>
-#include <cmath>
 #include <cstdio>
 #include <iostream>
 #include <memory>
 #include <random>
 #include <string>
+#include <vector>
 
 // ============================================================================
-// NNPlayer: wraps a TorchScript model using PartialGame for feature encoding
+// Classic policy types
 // ============================================================================
 
-class NNPlayer : public Player {
-public:
-    NNPlayer(torch::jit::Module& model, torch::Device device)
-        : model_(model), device_(device) {}
+enum class ClassicType { Random, Greedy, Other };
 
-protected:
-    Move select_move_impl() override {
-        auto legal      = game_.get_legal_moves();
-        const int K     = (int)legal.size();
-        auto player_hand = game_.player_hand();
-        auto discard    = game_.discard_pile();
-        int  opp_count  = game_.opponent_hand_size();
-
-        std::array<int,13> opp_counts{};
-        HandBits opp_bits{};
-        for (int r = 0; r < 13; ++r) {
-            int om = std::max(0, max_cards_in_deck_for_rank(r) - player_hand[r] - discard[r]);
-            opp_counts[r] = om;
-            if (om >= 1) opp_bits.at1 |= static_cast<uint16_t>(1u << r);
-            if (om >= 2) opp_bits.at2 |= static_cast<uint16_t>(1u << r);
-            if (om >= 3) opp_bits.at3 |= static_cast<uint16_t>(1u << r);
-            if (om >= 4) opp_bits.at4 |= static_cast<uint16_t>(1u << r);
-        }
-
-        auto float_opts = torch::TensorOptions().dtype(torch::kFloat32);
-        auto bool_opts  = torch::TensorOptions().dtype(torch::kBool);
-        torch::Tensor t_hand = torch::zeros({K, ENCODING_DIM}, float_opts);
-        torch::Tensor t_opp  = torch::zeros({K, ENCODING_DIM}, float_opts);
-        torch::Tensor t_move = torch::zeros({K, ENCODING_DIM}, float_opts);
-        torch::Tensor t_hint = torch::zeros({K}, float_opts);
-        torch::Tensor t_flag = torch::zeros({K}, bool_opts);
-        torch::Tensor t_pass = torch::zeros({K}, bool_opts);
-
-        float* h_hand = t_hand.data_ptr<float>();
-        float* h_opp  = t_opp.data_ptr<float>();
-        float* h_move = t_move.data_ptr<float>();
-        float* h_hint = t_hint.data_ptr<float>();
-        bool*  h_flag = t_flag.data_ptr<bool>();
-        bool*  h_pass = t_pass.data_ptr<bool>();
-
-        for (int i = 0; i < K; ++i) {
-            int mid = legal[i];
-            bool is_pass_move = (mid == kPASS);
-            std::array<int,13> mc{};
-            if (!is_pass_move)
-                for (int r = 0; r < 13; ++r) mc[r] = MOVE_TO_CARDS[mid][r];
-            std::array<int,13> hand_after{};
-            for (int r = 0; r < 13; ++r) hand_after[r] = player_hand[r] - mc[r];
-
-            encode_exact(hand_after,  h_hand + i * ENCODING_DIM);
-            encode_thermo(opp_counts, h_opp  + i * ENCODING_DIM);
-            encode_exact(mc,          h_move + i * ENCODING_DIM);
-
-            bool flag_val = !is_pass_move && !opponent_can_respond(mid, opp_bits, opp_count);
-            h_hint[i] = is_pass_move ? 0.0f : (flag_val ? 1.0f : (1.0f - kHintTable[mid]));
-            h_flag[i] = flag_val;
-            h_pass[i] = is_pass_move;
-        }
-
-        torch::NoGradGuard no_grad;
-        auto out = model_.forward({
-            t_hand.to(device_), t_opp.to(device_), t_move.to(device_),
-            t_hint.to(device_), t_flag.to(device_), t_pass.to(device_)
-        }).toTuple();
-
-        auto vi  = out->elements()[0].toTensor().to(torch::kCPU);
-        auto vn  = out->elements()[1].toTensor().to(torch::kCPU);
-        auto pt  = out->elements()[2].toTensor().to(torch::kCPU);
-        auto* vi_p = vi.data_ptr<float>();
-        auto* vn_p = vn.data_ptr<float>();
-        auto* pt_p = pt.data_ptr<float>();
-
-        int   best   = 0;
-        float best_w = -1.0f;
-        for (int i = 0; i < K; ++i) {
-            float w = pt_p[i] * vi_p[i] + (1.0f - pt_p[i]) * vn_p[i];
-            if (w > best_w) { best_w = w; best = i; }
-        }
-        return Move(legal[best]);
-    }
-
-private:
-    torch::jit::Module& model_;
-    torch::Device device_;
-};
-
-class NNPlayerFactory : public PlayerFactory {
-public:
-    NNPlayerFactory(torch::jit::Module& model, torch::Device device)
-        : model_(model), device_(device) {}
-
-    std::unique_ptr<Player> create_player() override {
-        return std::make_unique<NNPlayer>(model_, device_);
-    }
-
-private:
-    torch::jit::Module& model_;
-    torch::Device device_;
-};
-
-// ============================================================================
-// Wilson score 95% CI
-// ============================================================================
-
-struct WilsonCI { double lo, hi; };
-static WilsonCI wilson_ci(double p_hat, long n, double z = 1.96) {
-    double z2 = z*z, n_inv = 1.0/(double)n;
-    double center = (p_hat + z2*n_inv/2.0) / (1.0 + z2*n_inv);
-    double half = z * std::sqrt(p_hat*(1.0-p_hat)*n_inv + z2*n_inv*n_inv/4.0) /
-                  (1.0 + z2*n_inv);
-    return {center - half, center + half};
+static ClassicType classify(const std::string& name) {
+    if (name == "random") return ClassicType::Random;
+    if (name == "greedy") return ClassicType::Greedy;
+    return ClassicType::Other;
 }
 
-static std::string format_elapsed(long long ms) {
-    if (ms < 1000) { char b[32]; std::snprintf(b, sizeof(b), "%lld ms", ms); return b; }
-    double s = ms/1000.0; char b[64];
-    if (s < 60) std::snprintf(b, sizeof(b), "%.1f s", s);
-    else        std::snprintf(b, sizeof(b), "%dm %ds", (int)(s/60), (int)s%60);
-    return b;
+// ============================================================================
+// Inline classic move selection (no Player object needed)
+// ============================================================================
+
+static int select_random(const std::vector<int>& legal, std::mt19937& rng) {
+    int idx = std::uniform_int_distribution<int>(0, (int)legal.size()-1)(rng);
+    return legal[idx];
 }
+
+// Greedy: maximise GreedyEval of post-move hand; pass only if no non-pass move.
+static int select_greedy(const Game& game, int cp, const std::vector<int>& legal) {
+    auto hand = game.player_hand(cp);
+
+    int best_mid = -1;
+    GreedyEval best_eval{};
+
+    for (int mid : legal) {
+        if (mid == kPASS) continue;
+        std::array<int,13> hand_after{};
+        for (int r = 0; r < 13; ++r)
+            hand_after[r] = hand[r] - MOVE_TO_CARDS[mid][r];
+
+        int n_cards = 0, n_bombs = 0;
+        for (int i = 0; i < 13; ++i) {
+            n_cards += hand_after[i];
+            if ((i < 11 && hand_after[i] == 4) || (i == 11 && hand_after[i] == 3)) ++n_bombs;
+        }
+        GreedyEval ev;
+        ev.win_now       = (n_cards == 0) ? 1 : 0;
+        ev.bombs         = n_bombs;
+        ev.neg_num_cards = -n_cards;
+        ev.num_2s        = hand_after[12]; ev.num_as  = hand_after[11]; ev.num_ks  = hand_after[10];
+        ev.num_qs        = hand_after[9];  ev.num_js  = hand_after[8];  ev.num_10s = hand_after[7];
+        ev.num_9s        = hand_after[6];  ev.num_8s  = hand_after[5];  ev.num_7s  = hand_after[4];
+        ev.num_6s        = hand_after[3];  ev.num_5s  = hand_after[2];  ev.num_4s  = hand_after[1];
+
+        if (best_mid == -1 || best_eval < ev) { best_eval = ev; best_mid = mid; }
+    }
+    return (best_mid != -1) ? best_mid : kPASS;
+}
+
+// ============================================================================
+// Eval slot
+// ============================================================================
+
+struct EvalSlot {
+    Game game;
+    int  deal_id;
+    int  nn_player;          // seat (0 or 1) occupied by NN
+    std::vector<int> legal;  // cached when NN decision is needed
+    std::unique_ptr<Player> classic;  // non-null for Other (e.g. PIMC)
+    std::mt19937 slot_rng;            // for random classic moves
+    bool done{false};
+    int  nn_wins{0};
+};
+
+// Apply an NN move to the game and keep classic Player (PIMC) in sync.
+static void apply_and_sync_nn_move(EvalSlot& sl, int move_id) {
+    sl.game.apply_move(move_id);
+    if (sl.classic) sl.classic->accept_opponent_move(Move(move_id));
+}
+
+// Advance slot until game over or NN decision is needed.
+// Classic moves (random/greedy/Player) are consumed inline.
+static void advance_to_nn_decision(EvalSlot& sl, ClassicType ctype) {
+    while (!sl.game.is_over()) {
+        int cp = sl.game.current_player();
+        sl.legal = sl.game.get_legal_moves();
+
+        // ── NN side ──────────────────────────────────────────────────────────
+        if (cp == sl.nn_player) {
+            int tb = tablebase_move_id(sl.game, cp, sl.legal);
+            if (tb >= 0) { apply_and_sync_nn_move(sl, tb); continue; }
+            if ((int)sl.legal.size() == 1) { apply_and_sync_nn_move(sl, sl.legal[0]); continue; }
+            return;  // NN decision needed
+        }
+
+        // ── Classic side ─────────────────────────────────────────────────────
+        if (sl.classic) {
+            // Player-managed (PIMC): delegate all move selection to select_move(),
+            // which handles tablebase/forced/policy; applies to classic's game_ internally.
+            // Apply the same move to the authoritative Game state.
+            Move m = sl.classic->select_move();
+            sl.game.apply_move(encodeMove(m));
+        } else {
+            // Inline (random/greedy): handle tablebase/forced here for consistency.
+            int tb = tablebase_move_id(sl.game, cp, sl.legal);
+            if (tb >= 0) { sl.game.apply_move(tb); continue; }
+            if ((int)sl.legal.size() == 1) { sl.game.apply_move(sl.legal[0]); continue; }
+            int mid = (ctype == ClassicType::Random) ?
+                      select_random(sl.legal, sl.slot_rng) :
+                      select_greedy(sl.game, cp, sl.legal);
+            sl.game.apply_move(mid);
+        }
+    }
+}
+
+// ============================================================================
+// Reporting
+// ============================================================================
 
 static void print_usage(const char* prog) {
     std::cout << "Usage: " << prog
-              << " --model PATH --vs PLAYER [--vs-param F] --deals N [--seed S] [--device auto|cpu|cuda]\n"
+              << " --model PATH --vs PLAYER [--vs-param F] --deals N [--seed S] [--device D]\n"
               << "Options:\n"
-              << "  --model PATH     NN model (TorchScript .pt); plays as model0\n"
-              << "  --vs PLAYER      Classic opponent: random, greedy, pimc, etc.\n"
-              << "  --vs-param F     Parameter for classic player (default: 0.0)\n"
+              << "  --model PATH     NN model (TorchScript .pt)\n"
+              << "  --vs PLAYER      Classic opponent: random, greedy, pimc, ...\n"
+              << "  --vs-param F     Parameter for classic player (default: 0)\n"
               << "  --deals N        Paired deals; total games = 2*N\n"
               << "  --seed S         RNG seed (default: random)\n"
               << "  --device D       auto|cpu|cuda (default: auto)\n";
@@ -177,13 +166,13 @@ int main(int argc, char** argv) {
 
     for (int i = 1; i < argc; ++i) {
         std::string a = argv[i];
-        if      (a == "--help"     || a == "-h")  { print_usage(argv[0]); return 0; }
-        else if (a == "--model"    && i+1 < argc)  model_path = argv[++i];
-        else if (a == "--vs"       && i+1 < argc)  vs_name    = argv[++i];
-        else if (a == "--vs-param" && i+1 < argc)  vs_param   = std::stod(argv[++i]);
-        else if (a == "--deals"    && i+1 < argc)  n_deals    = std::stoi(argv[++i]);
-        else if (a == "--seed"     && i+1 < argc)  seed       = (unsigned)std::stoul(argv[++i]);
-        else if (a == "--device"   && i+1 < argc)  device_str = argv[++i];
+        if      (a == "--help"     || a == "-h") { print_usage(argv[0]); return 0; }
+        else if (a == "--model"    && i+1 < argc) model_path = argv[++i];
+        else if (a == "--vs"       && i+1 < argc) vs_name    = argv[++i];
+        else if (a == "--vs-param" && i+1 < argc) vs_param   = std::stod(argv[++i]);
+        else if (a == "--deals"    && i+1 < argc) n_deals    = std::stoi(argv[++i]);
+        else if (a == "--seed"     && i+1 < argc) seed       = (unsigned)std::stoul(argv[++i]);
+        else if (a == "--device"   && i+1 < argc) device_str = argv[++i];
         else { std::cerr << "Unknown arg: " << a << "\n"; print_usage(argv[0]); return 1; }
     }
     if (model_path.empty() || vs_name.empty() || n_deals <= 0) {
@@ -191,21 +180,26 @@ int main(int argc, char** argv) {
         print_usage(argv[0]); return 1;
     }
 
+    ClassicType ctype = classify(vs_name);
+
+    // For non-inline classic players we need a factory to create per-slot players.
+    std::shared_ptr<PlayerFactory> classic_factory;
+    if (ctype == ClassicType::Other) {
+        classic_factory = make_player_factory(vs_name, vs_param, seed);
+        if (!classic_factory) {
+            std::cerr << "Unknown player: " << vs_name << "\n"; return 1;
+        }
+    }
+
     torch::Device device = torch::kCPU;
-    if      (device_str == "auto")  device = torch::cuda::is_available() ? torch::kCUDA : torch::kCPU;
-    else if (device_str == "cuda")  device = torch::kCUDA;
+    if      (device_str == "auto") device = torch::cuda::is_available() ? torch::kCUDA : torch::kCPU;
+    else if (device_str == "cuda") device = torch::kCUDA;
     else if (device_str != "cpu") { std::cerr << "Unknown device: " << device_str << "\n"; return 1; }
     std::cout << "Device: " << (device == torch::kCUDA ? "cuda" : "cpu") << "\n";
 
     std::cout << "Loading model: " << model_path << "\n";
     torch::jit::Module model = torch::jit::load(model_path);
     model.eval(); model.to(device);
-
-    NNPlayerFactory nn_factory(model, device);
-    auto classic_factory = make_player_factory(vs_name, vs_param, seed);
-    if (!classic_factory) {
-        std::cerr << "Unknown player: " << vs_name << "\n"; return 1;
-    }
 
     std::string vs_label = vs_name;
     if (vs_param != 0.0) {
@@ -214,55 +208,85 @@ int main(int argc, char** argv) {
     }
 
     long total_games = 2L * n_deals;
-    std::cout << "\n=== NN vs Classic: model0 vs " << vs_label << " ===\n"
+    std::cout << "\n=== NN vs Classic: NN vs " << vs_label << " ===\n"
               << "Deals: " << n_deals << "  |  Games: " << total_games << "\n"
               << "Seed: " << seed << "\n\n";
 
-    long nn_wins = 0;
-    long p0_sweep = 0, split_count = 0, p1_sweep = 0;
+    // ── Initialise pool ───────────────────────────────────────────────────────
+    std::vector<EvalSlot> pool(2 * n_deals);
+    std::vector<int> deal_nn_wins(n_deals, 0);
 
-    auto t_start = std::chrono::high_resolution_clock::now();
+    for (int d = 0; d < n_deals; ++d) {
+        for (int seat = 0; seat < 2; ++seat) {
+            EvalSlot& sl = pool[2*d + seat];
+            std::mt19937 rng(seed + (unsigned)d);
+            sl.game.shuffle_deal(rng);
+            sl.deal_id   = d;
+            sl.nn_player = seat;  // seat 0: NN is player 0; seat 1: NN is player 1
+            sl.slot_rng  = std::mt19937(seed + (unsigned)(d * 1000 + seat));
 
-    for (int deal = 0; deal < n_deals; ++deal) {
-        unsigned int unit_seed = seed + (unsigned int)deal;
-        int deal_nn_wins = 0;
-
-        // Game 1: NN=p0, classic=p1
-        {
-            std::mt19937 rng(unit_seed);
-            auto p0 = nn_factory.create_player();
-            auto p1 = classic_factory->create_player();
-            GameSimulator sim(std::move(p0), std::move(p1), rng);
-            if (sim.run().game().get_winner() == 0) ++deal_nn_wins;
-        }
-        // Game 2: classic=p0, NN=p1 (same seed = same deal)
-        {
-            std::mt19937 rng(unit_seed);
-            auto p0 = classic_factory->create_player();
-            auto p1 = nn_factory.create_player();
-            GameSimulator sim(std::move(p0), std::move(p1), rng);
-            if (sim.run().game().get_winner() == 1) ++deal_nn_wins;
-        }
-
-        nn_wins += deal_nn_wins;
-        if      (deal_nn_wins == 2) ++p0_sweep;
-        else if (deal_nn_wins == 0) ++p1_sweep;
-        else                        ++split_count;
-
-        if ((deal + 1) % 50 == 0 || deal + 1 == n_deals) {
-            auto now = std::chrono::high_resolution_clock::now();
-            double elapsed = std::chrono::duration<double>(now - t_start).count();
-            double rate = elapsed > 0 ? 2.0 * (deal + 1) / elapsed : 0;
-            std::fprintf(stderr, "\rDeals: %d/%d  |  %.0f games/s   ",
-                         deal + 1, n_deals, rate);
-            std::fflush(stderr);
+            if (classic_factory) {
+                sl.classic = classic_factory->create_player();
+                sl.classic->accept_deal(sl.game, 1 - seat);  // classic is the other seat
+            }
         }
     }
-    std::fprintf(stderr, "\n");
+
+    auto t_start = std::chrono::high_resolution_clock::now();
+    int n_done = 0;
+
+    // ── Pool-based eval loop ──────────────────────────────────────────────────
+    while (n_done < (int)pool.size()) {
+
+        // 1. Advance all active slots to NN decision points (classic moves inline).
+        std::vector<int> nn_idx;
+
+        for (int si = 0; si < (int)pool.size(); ++si) {
+            EvalSlot& sl = pool[si];
+            if (sl.done) continue;
+
+            advance_to_nn_decision(sl, ctype);
+
+            if (sl.game.is_over()) {
+                sl.done = true;
+                ++n_done;
+                if (sl.game.get_winner() == sl.nn_player) ++deal_nn_wins[sl.deal_id];
+            } else {
+                nn_idx.push_back(si);
+            }
+        }
+
+        if (n_done == (int)pool.size()) break;
+
+        // 2. Batch forward pass for NN positions.
+        if (!nn_idx.empty()) {
+            std::vector<NNPosition> pos;
+            pos.reserve(nn_idx.size());
+            for (int si : nn_idx)
+                pos.emplace_back(&pool[si].game, pool[si].game.current_player(), &pool[si].legal);
+            auto best = batch_nn_select(model, device, pos);
+            for (int i = 0; i < (int)nn_idx.size(); ++i) {
+                EvalSlot& sl = pool[nn_idx[i]];
+                int move_id = sl.legal[best[i]];
+                apply_and_sync_nn_move(sl, move_id);
+            }
+        }
+    }
 
     auto t_end = std::chrono::high_resolution_clock::now();
     long long elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
         t_end - t_start).count();
+
+    // ── Aggregate results ─────────────────────────────────────────────────────
+    long nn_wins = 0;
+    long p0_sweep = 0, split_count = 0, p1_sweep = 0;
+    for (int d = 0; d < n_deals; ++d) {
+        int w = deal_nn_wins[d];
+        nn_wins += w;
+        if      (w == 2) ++p0_sweep;
+        else if (w == 0) ++p1_sweep;
+        else             ++split_count;
+    }
 
     double p_hat = (double)nn_wins / (double)total_games;
     WilsonCI ci  = wilson_ci(p_hat, total_games);
@@ -277,24 +301,18 @@ int main(int argc, char** argv) {
     else                   std::cout << "Result: no significant difference (CI includes 50%)\n";
 
     double inv = 1.0 / n_deals;
-    std::cout << "Deals: nn_sweep=" << p0_sweep << " split=" << split_count
-              << " classic_sweep=" << p1_sweep << "\n";
-    std::cout.precision(2);
-    std::cout << "Deals: nn 2-0: " << p0_sweep
-              << " (" << 100.0 * p0_sweep * inv << "%)  split 1-1: " << split_count
-              << " (" << 100.0 * split_count * inv << "%)  classic 2-0: " << p1_sweep
+    std::cout << "Deals: WW=" << p0_sweep
+              << " (" << 100.0 * p0_sweep * inv << "%)  split=" << split_count
+              << " (" << 100.0 * split_count * inv << "%)  LL=" << p1_sweep
               << " (" << 100.0 * p1_sweep * inv << "%)\n";
 
     long n_decisive = p0_sweep + p1_sweep;
     if (n_decisive > 0) {
         double p_dec = (double)p0_sweep / (double)n_decisive;
         WilsonCI ci_dec = wilson_ci(p_dec, n_decisive);
-        std::cout << "Among decisive: nn " << p0_sweep << " / " << n_decisive
+        std::cout << "Among decisive: NN " << p0_sweep << " / " << n_decisive
                   << " (" << 100.0 * p_dec << "%)  CI: ["
                   << 100.0 * ci_dec.lo << "%, " << 100.0 * ci_dec.hi << "%]\n";
-        if      (ci_dec.lo > 0.50) std::cout << "Result (decisive): NN sweeps more\n";
-        else if (ci_dec.hi < 0.50) std::cout << "Result (decisive): " << vs_label << " sweeps more\n";
-        else                        std::cout << "Result (decisive): no significant difference\n";
     }
 
     std::cout << "Elapsed: " << format_elapsed(elapsed_ms)

--- a/src/datagen/generate_nn_selfplay.cpp
+++ b/src/datagen/generate_nn_selfplay.cpp
@@ -382,6 +382,7 @@ static void print_usage(const char* prog) {
         << "  --out <path>      Output .parquet file (required)\n"
         << "  --pool <P>        Games per pool (default: 900, total 2P in flight)\n"
         << "  --seed <S>        RNG seed (default: random)\n"
+        << "  --temp <T>        Softmax temperature for move selection (default: 0 = argmax)\n"
         << "  --device <d>      cuda or cpu (default: cuda if available)\n"
         << "\nRuns NN self-play with double-buffer CPU/GPU pipeline.\n"
         << "Two independent pools of P games each; while GPU runs inference\n"
@@ -391,6 +392,7 @@ static void print_usage(const char* prog) {
 int main(int argc, char** argv) {
     int         num_games  = 0;
     int         pool_size  = 900;
+    float       temp       = 0.0f;
     std::string out_path;
     std::string model_path;
     std::string device_str = "auto";
@@ -404,6 +406,7 @@ int main(int argc, char** argv) {
         else if (arg=="--out"    && i+1<argc) out_path    = argv[++i];
         else if (arg=="--pool"   && i+1<argc) pool_size   = std::stoi(argv[++i]);
         else if (arg=="--seed"   && i+1<argc) seed        = std::stoul(argv[++i]);
+        else if (arg=="--temp"   && i+1<argc) temp        = std::stof(argv[++i]);
         else if (arg=="--device" && i+1<argc) device_str  = argv[++i];
         else { std::cerr << "Unknown: " << arg << "\n"; print_usage(argv[0]); return 1; }
     }
@@ -423,6 +426,7 @@ int main(int argc, char** argv) {
               << "Out:     " << out_path    << "\n"
               << "Seed:    " << seed        << "\n"
               << "Pool:    " << pool_size   << " per pool (" << 2*pool_size << " total in flight)\n"
+              << "Temp:    " << temp        << (temp==0?"  (argmax)":"") << "\n"
               << "Device:  " << (dev==torch::kCUDA ? "cuda" : "cpu") << "\n\n";
 
     torch::jit::Module model = torch::jit::load(model_path);
@@ -490,16 +494,35 @@ int main(int argc, char** argv) {
                 auto& slot = pool[g];
                 if (!slot.active) continue;
 
-                // Find best move for this slot
-                float best_w = -1e9f;
+                // Select move: argmax when temp==0, softmax sampling otherwise
                 int   best_row = -1;
                 const float* vi = buf.v_init.data_ptr<float>();
                 const float* vn = buf.v_no_init.data_ptr<float>();
                 const float* pt = buf.p_trick.data_ptr<float>();
+                const int row0  = buf.game_row_start[g];
+                const int row1  = buf.game_row_end[g];
 
-                for (int row = buf.game_row_start[g]; row < buf.game_row_end[g]; ++row) {
-                    float w = pt[row]*vi[row] + (1.0f-pt[row])*vn[row];
-                    if (w > best_w) { best_w = w; best_row = row; }
+                if (temp == 0.0f) {
+                    float best_w = -1e9f;
+                    for (int row = row0; row < row1; ++row) {
+                        float w = pt[row]*vi[row] + (1.0f-pt[row])*vn[row];
+                        if (w > best_w) { best_w = w; best_row = row; }
+                    }
+                } else {
+                    // Softmax sampling: exp((w - max_w) / temp), then sample
+                    float max_w = -1e9f;
+                    for (int row = row0; row < row1; ++row) {
+                        float w = pt[row]*vi[row] + (1.0f-pt[row])*vn[row];
+                        if (w > max_w) max_w = w;
+                    }
+                    std::vector<float> probs;
+                    probs.reserve(row1 - row0);
+                    for (int row = row0; row < row1; ++row) {
+                        float w = pt[row]*vi[row] + (1.0f-pt[row])*vn[row];
+                        probs.push_back(std::exp((w - max_w) / temp));
+                    }
+                    std::discrete_distribution<int> dist(probs.begin(), probs.end());
+                    best_row = row0 + dist(rng);
                 }
                 if (best_row < 0) continue;
 

--- a/src/datagen/generate_nn_selfplay.cpp
+++ b/src/datagen/generate_nn_selfplay.cpp
@@ -9,6 +9,7 @@
 // Output format: identical to generate_nn_data (same Parquet schema).
 
 #include "nn_game_runner.h"
+#include "nn_encode.h"
 #include "parquet_export.hpp"
 
 #include "game.h"
@@ -42,36 +43,8 @@
 // Constants
 // ---------------------------------------------------------------------------
 
-static constexpr int ENCODING_DIM = 48;  // one-hot floats per hand/opp/move
 static constexpr int MAX_BATCH    = 200000;  // upper bound on positions per round
 static const char* kAtNames[4]    = { "at1", "at2", "at3", "at4" };
-
-// RANK_MAX_COUNTS[r] = max cards of rank r in deck
-static constexpr int RANK_MAX[13] = {4,4,4,4,4,4,4,4,4,4,4,3,1};
-
-// ---------------------------------------------------------------------------
-// Encoding helpers
-// ---------------------------------------------------------------------------
-
-// Write exact one-hot encoding for rank counts into buf (48 floats).
-static void encode_exact(const std::array<int,13>& counts, float* buf) {
-    int off = 0;
-    for (int r = 0; r < 13; ++r) {
-        int c = counts[r], mx = RANK_MAX[r];
-        for (int k = 1; k <= mx; ++k)
-            buf[off++] = (c == k) ? 1.0f : 0.0f;
-    }
-}
-
-// Write thermometer (upper-bound) encoding for max possible counts.
-static void encode_thermo(const std::array<int,13>& counts, float* buf) {
-    int off = 0;
-    for (int r = 0; r < 13; ++r) {
-        int c = std::min(counts[r], RANK_MAX[r]), mx = RANK_MAX[r];
-        for (int k = 1; k <= mx; ++k)
-            buf[off++] = (c >= k) ? 1.0f : 0.0f;
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Tablebase detection (mirror of nn_game_runner.cpp)
@@ -239,7 +212,10 @@ static void encode_pool(const std::vector<GameSlot>& pool, InferBuf& buf) {
             std::array<int,13> mc{};
             for (int r = 0; r < 13; ++r) mc[r] = MOVE_TO_CARDS[move_id][r];
 
-            encode_exact(hand_counts,  h_hand + row*ENCODING_DIM);
+            // Post-move hand (model was trained with hand-after-playing-move as input)
+            std::array<int,13> hand_after{};
+            for (int r = 0; r < 13; ++r) hand_after[r] = hand_counts[r] - mc[r];
+            encode_exact(hand_after,   h_hand + row*ENCODING_DIM);
             encode_thermo(opp_counts,  h_opp  + row*ENCODING_DIM);
             encode_exact(mc,           h_move + row*ENCODING_DIM);
 

--- a/src/datagen/generate_nn_selfplay.cpp
+++ b/src/datagen/generate_nn_selfplay.cpp
@@ -44,7 +44,6 @@
 // ---------------------------------------------------------------------------
 
 static constexpr int MAX_BATCH    = 200000;  // upper bound on positions per round
-static const char* kAtNames[4]    = { "at1", "at2", "at3", "at4" };
 
 // ---------------------------------------------------------------------------
 // Tablebase detection (mirror of nn_game_runner.cpp)
@@ -120,9 +119,11 @@ struct PosRecord {
     float hint;
     bool  flag;
     bool  pass_;
+    bool  vi_forced;
+    bool  vn_forced;
     std::array<int,13> move_enc;
-    uint16_t hand_at[4];
-    uint16_t opp_at[4];
+    std::array<int,13> hand_after;   // post-move rank counts
+    std::array<int,13> opp_counts;   // opponent max rank counts
 };
 
 // ---------------------------------------------------------------------------
@@ -135,6 +136,7 @@ struct GameSlot {
     NNGameData       data{};    // accumulates turns for this game
     bool             active{false};
     int              global_id{-1};
+    int              trick_start{0};  // index into data.turns of current trick start
 };
 
 // ---------------------------------------------------------------------------
@@ -194,9 +196,9 @@ static void encode_pool(const std::vector<GameSlot>& pool, InferBuf& buf) {
         auto discard     = slot.game.discard_pile();
         int  opp_count   = slot.game.get_player_hand_size(1 - cp);
 
-        // Opponent upper-bound counts + HandBits (constant across all moves for this slot)
+        // Opponent upper-bound counts (constant across all moves for this slot)
         std::array<int,13> opp_counts{};
-        HandBits opp_bits{};
+        HandBits opp_bits{};  // still needed for opponent_can_respond()
         for (int r = 0; r < 13; ++r) {
             int hand_r = ((hb.at1>>r)&1)+((hb.at2>>r)&1)+((hb.at3>>r)&1)+((hb.at4>>r)&1);
             int om = max_cards_in_deck_for_rank(r) - hand_r - discard[r];
@@ -228,15 +230,41 @@ static void encode_pool(const std::vector<GameSlot>& pool, InferBuf& buf) {
             h_flag[row] = is_flag;
             h_pass[row] = is_pass;
 
-            // Post-move hand bits (after applying this move)
-            HandBits post_hb = hb;
-            for (int r = 0; r < 13; ++r)
-                if (mc[r]) hand_bits_remove(post_hb, r, mc[r]);
+            // vi_forced: after playing this move, is there a forced win from initiative?
+            // Only check when remaining hand is small (perf gate).
+            bool vi_forced = false;
+            if (!is_pass) {
+                int remaining = 0;
+                for (int r = 0; r < 13; ++r) remaining += hand_after[r];
+                if (remaining <= 10) {
+                    std::array<int,13> discard_after;
+                    for (int r = 0; r < 13; ++r) discard_after[r] = discard[r] + mc[r];
+                    vi_forced = find_forced_win(hand_after, discard_after, opp_count).has_value();
+                }
+            }
 
-            buf.pos_map[row] = {g, mi, cp, hint_val, is_flag, is_pass,
-                                mc,
-                                {post_hb.at1, post_hb.at2, post_hb.at3, post_hb.at4},
-                                {opp_bits.at1, opp_bits.at2, opp_bits.at3, opp_bits.at4}};
+            // vn_forced: exactly 1 card remaining of rank R, and opp has <=1 card
+            // strictly below R → opponent's only below-R card is their last, so
+            // we can never win the trick without initiative (vn = 0 exactly).
+            bool vn_forced = false;
+            if (!is_pass) {
+                int remaining = 0;
+                int remaining_rank = -1;
+                for (int r = 0; r < 13; ++r) {
+                    remaining += hand_after[r];
+                    if (hand_after[r] > 0) remaining_rank = r;
+                }
+                if (remaining == 1 && remaining_rank >= 0) {
+                    int opp_below = 0;
+                    for (int r = 0; r < remaining_rank; ++r)
+                        opp_below += opp_counts[r];
+                    if (opp_below <= 1)
+                        vn_forced = true;
+                }
+            }
+
+            buf.pos_map[row] = {g, mi, cp, hint_val, is_flag, is_pass, vi_forced, vn_forced,
+                                mc, hand_after, opp_counts};
             ++row;
         }
         buf.game_row_end[g] = row;
@@ -269,6 +297,15 @@ static void run_inference(torch::jit::Module& model,
     buf.v_no_init = out->elements()[1].toTensor().to(torch::kCPU);
     buf.p_trick   = out->elements()[2].toTensor().to(torch::kCPU);
 }
+
+// ---------------------------------------------------------------------------
+// Game statistics (updated atomically by workers)
+// ---------------------------------------------------------------------------
+
+static constexpr int kMaxLegalHist = 512;
+static std::atomic<long long> stat_total_turns{0};
+static std::atomic<long long> stat_p1_wins{0};
+static std::atomic<long long> stat_legal_hist[kMaxLegalHist]{};
 
 // ---------------------------------------------------------------------------
 // Progress bar
@@ -313,15 +350,18 @@ static void write_nn_parquet(
     for (const auto& pr : sorted) total += pr.second.turns.size();
 
     arrow::Int32Builder   game_id_b, turn_idx_b, cp_b, winner_b;
-    arrow::Int32Builder   move_b[13], hand_at_b[4], opp_at_b[4];
+    arrow::Int32Builder   move_b[13], hand_after_b[13], opp_cnt_b[13];
     arrow::FloatBuilder   hint_b;
-    arrow::BooleanBuilder flag_b, pass_b;
+    arrow::BooleanBuilder flag_b, pass_b, vi_forced_b, vn_forced_b;
+    arrow::Int8Builder    trick_winner_b;
 
     auto reserve = [&](int64_t n) {
         game_id_b.Reserve(n); turn_idx_b.Reserve(n); cp_b.Reserve(n); winner_b.Reserve(n);
         hint_b.Reserve(n); flag_b.Reserve(n); pass_b.Reserve(n);
-        for (int r=0;r<13;++r) move_b[r].Reserve(n);
-        for (int i=0;i<4;++i) { hand_at_b[i].Reserve(n); opp_at_b[i].Reserve(n); }
+        vi_forced_b.Reserve(n); vn_forced_b.Reserve(n); trick_winner_b.Reserve(n);
+        for (int r=0;r<13;++r) {
+            move_b[r].Reserve(n); hand_after_b[r].Reserve(n); opp_cnt_b[r].Reserve(n);
+        }
     };
     reserve((int64_t)total);
 
@@ -331,17 +371,21 @@ static void write_nn_parquet(
             game_id_b.UnsafeAppend(gid); turn_idx_b.UnsafeAppend(tidx++);
             cp_b.UnsafeAppend(t.current_player); winner_b.UnsafeAppend(pr.second.winner);
             hint_b.UnsafeAppend(t.hint); flag_b.UnsafeAppend(t.flag); pass_b.UnsafeAppend(t.pass_);
-            for (int r=0;r<13;++r) move_b[r].UnsafeAppend(t.move_enc[r]);
-            for (int i=0;i<4;++i) {
-                hand_at_b[i].UnsafeAppend((int32_t)t.hand_at[i]);
-                opp_at_b[i].UnsafeAppend((int32_t)t.opp_at[i]);
+            vi_forced_b.UnsafeAppend(t.vi_forced);
+            vn_forced_b.UnsafeAppend(t.vn_forced);
+            trick_winner_b.UnsafeAppend(t.trick_winner);
+            for (int r=0;r<13;++r) {
+                move_b[r].UnsafeAppend(t.move_enc[r]);
+                hand_after_b[r].UnsafeAppend(t.hand_after[r]);
+                opp_cnt_b[r].UnsafeAppend(t.opp_counts[r]);
             }
         }
     }
 
-    auto fi = [](arrow::Int32Builder&   b){ std::shared_ptr<arrow::Array> a; b.Finish(&a); return a; };
-    auto ff = [](arrow::FloatBuilder&   b){ std::shared_ptr<arrow::Array> a; b.Finish(&a); return a; };
-    auto fb = [](arrow::BooleanBuilder& b){ std::shared_ptr<arrow::Array> a; b.Finish(&a); return a; };
+    auto fi  = [](arrow::Int32Builder&   b){ std::shared_ptr<arrow::Array> a; b.Finish(&a); return a; };
+    auto ff  = [](arrow::FloatBuilder&   b){ std::shared_ptr<arrow::Array> a; b.Finish(&a); return a; };
+    auto fb  = [](arrow::BooleanBuilder& b){ std::shared_ptr<arrow::Array> a; b.Finish(&a); return a; };
+    auto fi8 = [](arrow::Int8Builder&    b){ std::shared_ptr<arrow::Array> a; b.Finish(&a); return a; };
 
     std::vector<std::shared_ptr<arrow::Field>> fields;
     std::vector<std::shared_ptr<arrow::Array>> arrays;
@@ -351,15 +395,18 @@ static void write_nn_parquet(
     push(arrow::field("turn_idx",       arrow::int32()), fi(turn_idx_b));
     push(arrow::field("current_player", arrow::int32()), fi(cp_b));
     for (int r=0;r<13;++r)
-        push(arrow::field("move_at"+std::to_string(r), arrow::int32()), fi(move_b[r]));
-    for (int i=0;i<4;++i)
-        push(arrow::field(std::string("hand_")+kAtNames[i], arrow::int32()), fi(hand_at_b[i]));
-    for (int i=0;i<4;++i)
-        push(arrow::field(std::string("opp_")+kAtNames[i], arrow::int32()), fi(opp_at_b[i]));
-    push(arrow::field("hint",   arrow::float32()), ff(hint_b));
-    push(arrow::field("flag",   arrow::boolean()), fb(flag_b));
-    push(arrow::field("pass_",  arrow::boolean()), fb(pass_b));
-    push(arrow::field("winner", arrow::int32()),   fi(winner_b));
+        push(arrow::field("move_at"+std::to_string(r),      arrow::int32()), fi(move_b[r]));
+    for (int r=0;r<13;++r)
+        push(arrow::field("hand_after_"+std::to_string(r),  arrow::int32()), fi(hand_after_b[r]));
+    for (int r=0;r<13;++r)
+        push(arrow::field("opp_cnt_"+std::to_string(r),     arrow::int32()), fi(opp_cnt_b[r]));
+    push(arrow::field("hint",         arrow::float32()), ff(hint_b));
+    push(arrow::field("flag",         arrow::boolean()), fb(flag_b));
+    push(arrow::field("pass_",        arrow::boolean()), fb(pass_b));
+    push(arrow::field("vi_forced",    arrow::boolean()), fb(vi_forced_b));
+    push(arrow::field("vn_forced",    arrow::boolean()), fb(vn_forced_b));
+    push(arrow::field("trick_winner", arrow::int8()),    fi8(trick_winner_b));
+    push(arrow::field("winner",       arrow::int32()),   fi(winner_b));
 
     auto table = arrow::Table::Make(arrow::schema(fields), arrays);
     auto out = arrow::io::FileOutputStream::Open(path).ValueOrDie();
@@ -480,6 +527,14 @@ int main(int argc, char** argv) {
         int local_games_done = 0;
 
         while (games_done.load() < num_games) {
+            // Record legal move counts for stats
+            for (const auto& slot : pool) {
+                if (!slot.active) continue;
+                int k = (int)slot.legal.size();
+                if (k > 0 && k < kMaxLegalHist)
+                    stat_legal_hist[k].fetch_add(1, std::memory_order_relaxed);
+            }
+
             // Encode this pool's current decision points
             encode_pool(pool, buf);
 
@@ -530,17 +585,37 @@ int main(int argc, char** argv) {
                 int move_id = slot.legal[pr.move_idx];
 
                 slot.data.turns.push_back({
-                    pr.cp, pr.move_enc,
-                    {pr.hand_at[0],pr.hand_at[1],pr.hand_at[2],pr.hand_at[3]},
-                    {pr.opp_at[0], pr.opp_at[1], pr.opp_at[2], pr.opp_at[3]},
-                    pr.hint, pr.flag, pr.pass_
+                    pr.cp, pr.move_enc, pr.hand_after, pr.opp_counts,
+                    pr.hint, pr.flag, pr.pass_, pr.vi_forced, pr.vn_forced, 0
                 });
+
+                // Trick winner: when a pass lands, backfill the completed trick.
+                if (pr.pass_) {
+                    int n = (int)slot.data.turns.size();
+                    int winner_cp = (n >= 2) ? slot.data.turns[n-2].current_player : -1;
+                    for (int j = slot.trick_start; j < n; ++j)
+                        slot.data.turns[j].trick_winner =
+                            (winner_cp >= 0 &&
+                             slot.data.turns[j].current_player == winner_cp) ? 1 : 0;
+                    slot.trick_start = n;
+                }
 
                 slot.game.apply_move(move_id);
                 slot.legal = advance_to_decision(slot.game, rng);
 
                 if (slot.legal.empty()) {
+                    // Backfill the final trick (ended by emptying hand, not a pass).
+                    int last_cp = slot.data.turns.back().current_player;
+                    for (int j = slot.trick_start; j < (int)slot.data.turns.size(); ++j)
+                        slot.data.turns[j].trick_winner =
+                            (slot.data.turns[j].current_player == last_cp) ? 1 : 0;
+                    slot.trick_start = 0;
+
                     slot.data.winner = slot.game.get_winner();
+                    stat_total_turns.fetch_add((long long)slot.data.turns.size(),
+                                               std::memory_order_relaxed);
+                    if (slot.data.winner == 1)
+                        stat_p1_wins.fetch_add(1, std::memory_order_relaxed);
                     int gid = slot.global_id;
                     {
                         std::lock_guard<std::mutex> lk(data_mutex);
@@ -553,6 +628,7 @@ int main(int argc, char** argv) {
                         slot.global_id = global_id_counter.fetch_add(1);
                         slot.game.shuffle_deal(rng);
                         slot.data = {};
+                        slot.trick_start = 0;
                         slot.legal = advance_to_decision(slot.game, rng);
                         slot.active = !slot.legal.empty();
                     } else {
@@ -587,5 +663,36 @@ int main(int argc, char** argv) {
     std::cout << "Done. " << ms << " ms  ("
               << (ms>0 ? (long)(1000.0*num_games/ms) : 0) << " games/s)\n"
               << "Output: " << out_path << "\n";
+
+    // Print game statistics
+    long long total_turns = stat_total_turns.load();
+    long long p1_wins     = stat_p1_wins.load();
+    int actual = (int)completed.size();
+    std::cout << "\n=== Game Statistics ===\n";
+    std::cout << "Avg decision points/game: "
+              << (actual > 0 ? (double)total_turns / actual : 0.0) << "\n";
+    std::cout << "P1 win rate: "
+              << p1_wins << " / " << actual
+              << (actual > 0 ? " (" + std::to_string((int)(100.0*p1_wins/actual+0.5)) + "%)" : "")
+              << "\n";
+
+    // Legal move distribution
+    std::cout << "Legal move count distribution:\n";
+    std::cout << "  count  decisions  pct\n";
+    long long total_dp = 0;
+    for (int k = 0; k < kMaxLegalHist; ++k)
+        total_dp += stat_legal_hist[k].load();
+    // Print buckets that have data, grouped sparsely
+    long long cumul = 0;
+    for (int k = 1; k < kMaxLegalHist; ++k) {
+        long long v = stat_legal_hist[k].load();
+        if (v == 0) continue;
+        cumul += v;
+        char buf[128];
+        std::snprintf(buf, sizeof(buf), "  %5d  %9lld  %5.1f%%\n",
+                      k, v, total_dp > 0 ? 100.0*v/total_dp : 0.0);
+        std::cout << buf;
+    }
+
     return 0;
 }

--- a/src/datagen/nn_encode.h
+++ b/src/datagen/nn_encode.h
@@ -1,0 +1,28 @@
+#pragma once
+// Shared NN feature encoding utilities used by generate_nn_selfplay and eval_nn_match.
+
+#include <algorithm>
+#include <array>
+
+static constexpr int ENCODING_DIM = 48;
+static constexpr int RANK_MAX[13] = {4,4,4,4,4,4,4,4,4,4,4,3,1};
+
+// Exact one-hot encoding: bit i of rank r is set iff count[r] == i+1.
+inline void encode_exact(const std::array<int,13>& counts, float* buf) {
+    int off = 0;
+    for (int r = 0; r < 13; ++r) {
+        int c = counts[r], mx = RANK_MAX[r];
+        for (int k = 1; k <= mx; ++k)
+            buf[off++] = (c == k) ? 1.0f : 0.0f;
+    }
+}
+
+// Thermometer (upper-bound) encoding: bit i of rank r is set iff count[r] >= i+1.
+inline void encode_thermo(const std::array<int,13>& counts, float* buf) {
+    int off = 0;
+    for (int r = 0; r < 13; ++r) {
+        int c = std::min(counts[r], RANK_MAX[r]), mx = RANK_MAX[r];
+        for (int k = 1; k <= mx; ++k)
+            buf[off++] = (c >= k) ? 1.0f : 0.0f;
+    }
+}

--- a/src/datagen/play_games.cpp
+++ b/src/datagen/play_games.cpp
@@ -1,0 +1,351 @@
+// play_games: play fresh games with a NN model and print per-turn decisions.
+//
+// Both players use the same model. For each position the binary scores all
+// legal moves, picks the best (argmax w), and prints the top-2 with scores so
+// you can see how each player is reasoning.
+//
+// Usage:
+//   play_games --model PATH --games N [--out FILE] [--seed S]
+//              [--device auto|cpu|cuda]
+
+#include "nn_encode.h"
+
+#include "game.h"
+#include "hint_table.h"
+#include "util.h"
+
+#include <torch/script.h>
+#include <torch/cuda.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+// ============================================================================
+// Formatting helpers
+// ============================================================================
+
+// rankToChar takes actual rank values (3=three, ..., 14=ace, 2=two).
+// MOVE_TO_CARDS and player_hand() use array indices 0-12:
+//   idx 0..11 → ranks 3..14; idx 12 → rank 2 (the "two" high card).
+static inline char idx_to_char(int idx) {
+    return rankToChar(idx < 12 ? idx + 3 : 2);
+}
+
+static std::string fmt_hand(const std::array<int,13>& hand) {
+    std::string s;
+    for (int r = 0; r < 13; ++r)
+        for (int i = 0; i < hand[r]; ++i)
+            s += idx_to_char(r);
+    if (s.empty()) s = "(empty)";
+    return s;
+}
+
+static std::string fmt_move(int mid) {
+    if (mid == kPASS) return "pass";
+    const auto& mc = MOVE_TO_CARDS[mid];
+    int total = mc[13];
+
+    std::string cards;
+    int nz_count = 0, max_count = 0;
+    for (int r = 0; r < 13; ++r) {
+        if (mc[r]) { nz_count++; if (mc[r] > max_count) max_count = mc[r]; }
+        for (int i = 0; i < mc[r]; ++i) cards += idx_to_char(r);
+    }
+
+    std::string t;
+    if      (total == 1) t = "single";
+    else if (total == 2 && nz_count == 1) t = "pair";
+    else if (total == 3 && nz_count == 1) t = "trips";
+    else if (total == 4 && nz_count == 1 && max_count == 4) t = "quad";
+    else if (total == 5 && nz_count == 2 && max_count == 3) t = "FH";
+    else if (total >= 5 && nz_count == total) t = "str";
+    else if (max_count == 4) {
+        int extra = total - 4;
+        t = extra ? "bomb+" + std::to_string(extra) : "bomb";
+    }
+    else t = std::to_string(total) + "c";
+
+    return t + "(" + cards + ")";
+}
+
+// ============================================================================
+// Per-move scoring
+// ============================================================================
+
+struct ScoredMove { int mid; float vi, vn, pt, w; };
+
+static std::vector<ScoredMove> score_moves(
+    torch::jit::Module& model, torch::Device device,
+    const Game& game, int player_num,
+    const std::vector<int>& legal_moves)
+{
+    const int K = (int)legal_moves.size();
+
+    HandBits hb      = game.player_hand_bits(player_num);
+    auto discard     = game.discard_pile();
+    auto hand_counts = hand_bits_to_counts(hb);
+    int  opp_count   = game.get_player_hand_size(1 - player_num);
+
+    std::array<int,13> opp_counts{};
+    HandBits opp_bits{};
+    for (int r = 0; r < 13; ++r) {
+        int hand_r = ((hb.at1>>r)&1)+((hb.at2>>r)&1)+((hb.at3>>r)&1)+((hb.at4>>r)&1);
+        int om = std::max(0, max_cards_in_deck_for_rank(r) - hand_r - discard[r]);
+        opp_counts[r] = om;
+        if (om >= 1) opp_bits.at1 |= static_cast<uint16_t>(1u << r);
+        if (om >= 2) opp_bits.at2 |= static_cast<uint16_t>(1u << r);
+        if (om >= 3) opp_bits.at3 |= static_cast<uint16_t>(1u << r);
+        if (om >= 4) opp_bits.at4 |= static_cast<uint16_t>(1u << r);
+    }
+
+    auto float_opts = torch::TensorOptions().dtype(torch::kFloat32);
+    auto bool_opts  = torch::TensorOptions().dtype(torch::kBool);
+    torch::Tensor t_hand = torch::zeros({K, ENCODING_DIM}, float_opts);
+    torch::Tensor t_opp  = torch::zeros({K, ENCODING_DIM}, float_opts);
+    torch::Tensor t_move = torch::zeros({K, ENCODING_DIM}, float_opts);
+    torch::Tensor t_hint = torch::zeros({K}, float_opts);
+    torch::Tensor t_flag = torch::zeros({K}, bool_opts);
+    torch::Tensor t_pass = torch::zeros({K}, bool_opts);
+
+    float* h_hand = t_hand.data_ptr<float>();
+    float* h_opp  = t_opp.data_ptr<float>();
+    float* h_move = t_move.data_ptr<float>();
+    float* h_hint = t_hint.data_ptr<float>();
+    bool*  h_flag = t_flag.data_ptr<bool>();
+    bool*  h_pass = t_pass.data_ptr<bool>();
+
+    for (int i = 0; i < K; ++i) {
+        int mid = legal_moves[i];
+        bool is_pass_move = (mid == kPASS);
+
+        std::array<int,13> mc{};
+        if (!is_pass_move)
+            for (int r = 0; r < 13; ++r) mc[r] = MOVE_TO_CARDS[mid][r];
+
+        std::array<int,13> hand_after{};
+        for (int r = 0; r < 13; ++r) hand_after[r] = hand_counts[r] - mc[r];
+
+        encode_exact(hand_after,  h_hand + i * ENCODING_DIM);
+        encode_thermo(opp_counts, h_opp  + i * ENCODING_DIM);
+        encode_exact(mc,          h_move + i * ENCODING_DIM);
+
+        bool flag_val = !is_pass_move && !opponent_can_respond(mid, opp_bits, opp_count);
+        h_hint[i] = is_pass_move ? 0.0f : (flag_val ? 1.0f : (1.0f - kHintTable[mid]));
+        h_flag[i] = flag_val;
+        h_pass[i] = is_pass_move;
+    }
+
+    torch::NoGradGuard no_grad;
+    auto out = model.forward({
+        t_hand.to(device), t_opp.to(device), t_move.to(device),
+        t_hint.to(device), t_flag.to(device), t_pass.to(device)
+    }).toTuple();
+
+    auto vi_t = out->elements()[0].toTensor().to(torch::kCPU);
+    auto vn_t = out->elements()[1].toTensor().to(torch::kCPU);
+    auto pt_t = out->elements()[2].toTensor().to(torch::kCPU);
+    auto* vi_p = vi_t.data_ptr<float>();
+    auto* vn_p = vn_t.data_ptr<float>();
+    auto* pt_p = pt_t.data_ptr<float>();
+
+    std::vector<ScoredMove> result;
+    result.reserve(K);
+    for (int i = 0; i < K; ++i) {
+        float w = pt_p[i] * vi_p[i] + (1.0f - pt_p[i]) * vn_p[i];
+        result.push_back({legal_moves[i], vi_p[i], vn_p[i], pt_p[i], w});
+    }
+    std::stable_sort(result.begin(), result.end(),
+                     [](const ScoredMove& a, const ScoredMove& b){ return a.w > b.w; });
+    return result;
+}
+
+// ============================================================================
+// Game play + printing
+// ============================================================================
+
+static constexpr int kMoveWidth = 20;
+
+static void play_and_print_game(torch::jit::Module& model, torch::Device device,
+                                 std::mt19937& rng, std::ostream& out, int game_num)
+{
+    Game game;
+    game.shuffle_deal(rng);
+
+    int trick = 1;
+    int winner = -1;
+
+    // Collect turn output into a buffer so we can prepend winner header
+    std::vector<std::string> lines;
+    lines.reserve(128);
+
+    while (!game.is_over()) {
+        int cp        = game.current_player();
+        int last_mid  = game.last_move_id();
+        bool init     = (last_mid == kPASS);
+        auto legal    = game.get_legal_moves();
+        auto hand     = game.player_hand(cp);
+        auto discard  = game.discard_pile();
+        int  hand_sz  = game.get_player_hand_size(cp);
+        int  opp_sz   = game.get_player_hand_size(1 - cp);
+        bool forced   = (legal.size() == 1);
+        bool endgame  = (opp_sz == 1);
+
+        // Context string
+        std::string ctx = init ? "Initiative" : ("vs " + fmt_move(last_mid));
+        std::string eg  = endgame ? "  [endgame]" : "";
+
+        std::string hdr = "  ── T" + std::to_string(trick) +
+                          "  P" + std::to_string(cp) +
+                          "  " + std::to_string(hand_sz) + " cards  " +
+                          ctx + eg + " ─";
+        lines.push_back(hdr);
+
+        // Discard: fmt_hand returns "(empty)" for an empty hand; show "—" instead
+        std::string dh = fmt_hand(discard);
+        std::string disc_s = (dh == "(empty)") ? "\xe2\x80\x94" : dh;  // — (em dash)
+        lines.push_back("  Hand: " + fmt_hand(hand));
+        lines.push_back("  Opp:  " + std::to_string(opp_sz) + " cards   Disc: " + disc_s);
+
+        int chosen_mid;
+        std::vector<ScoredMove> top2;
+
+        if (forced) {
+            chosen_mid = legal[0];
+        } else {
+            auto scored = score_moves(model, device, game, cp, legal);
+            chosen_mid  = scored[0].mid;
+            int n = std::min((int)scored.size(), 2);
+            for (int i = 0; i < n; ++i) top2.push_back(scored[i]);
+        }
+
+        if (forced) {
+            std::string mv = fmt_move(chosen_mid);
+            // pad to kMoveWidth
+            while ((int)mv.size() < kMoveWidth) mv += ' ';
+            lines.push_back("  ** " + mv + "  [forced]");
+        } else {
+            for (int i = 0; i < (int)top2.size(); ++i) {
+                const auto& sm = top2[i];
+                std::string label = (i == 0) ? "#1" : "#2";
+                std::string mv    = fmt_move(sm.mid);
+                while ((int)mv.size() < kMoveWidth) mv += ' ';
+                char score_buf[64];
+                std::snprintf(score_buf, sizeof(score_buf),
+                              "pt=%.2f vi=%.2f vn=%.2f w=%.2f",
+                              sm.pt, sm.vi, sm.vn, sm.w);
+                std::string chosen_mark = (sm.mid == chosen_mid) ? "  ←" : "   ";
+                lines.push_back("  " + label + " " + mv + "  " + score_buf + chosen_mark);
+            }
+        }
+
+        // Check for win before applying
+        int cards_played = (chosen_mid == kPASS) ? 0 : MOVE_TO_CARDS[chosen_mid][13];
+        if (hand_sz - cards_played == 0 && chosen_mid != kPASS)
+            winner = cp;
+
+        game.apply_move(chosen_mid);
+
+        if (chosen_mid == kPASS) trick++;
+    }
+
+    if (winner < 0) winner = game.get_winner();
+
+    // Write header + separator
+    out << "\n  game " << game_num
+        << "  (winner: P" << winner << ")\n";
+    out << "  " << std::string(72, '-') << "\n";
+    for (const auto& l : lines) out << l << "\n";
+    out << "\n  " << std::string(72, '-') << "\n\n";
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+static void print_usage(const char* prog) {
+    std::cout << "Usage: " << prog
+              << " --model PATH --games N [--out FILE] [--seed S]"
+                 " [--device auto|cpu|cuda]\n";
+}
+
+int main(int argc, char* argv[]) {
+    std::string model_path, out_path;
+    int n_games = 3;
+    unsigned seed = 42;
+    std::string device_str = "auto";
+
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if      (a == "--model"  && i+1 < argc) { model_path  = argv[++i]; }
+        else if (a == "--games"  && i+1 < argc) { n_games     = std::stoi(argv[++i]); }
+        else if (a == "--out"    && i+1 < argc) { out_path    = argv[++i]; }
+        else if (a == "--seed"   && i+1 < argc) { seed        = (unsigned)std::stoul(argv[++i]); }
+        else if (a == "--device" && i+1 < argc) { device_str  = argv[++i]; }
+        else if (a == "--help" || a == "-h") { print_usage(argv[0]); return 0; }
+        else { std::cerr << "Unknown argument: " << a << "\n"; print_usage(argv[0]); return 1; }
+    }
+
+    if (model_path.empty()) {
+        std::cerr << "Error: --model is required\n";
+        print_usage(argv[0]); return 1;
+    }
+
+    // Device
+    torch::Device device(torch::kCPU);
+    if (device_str == "auto")
+        device = torch::cuda::is_available() ? torch::Device(torch::kCUDA) : torch::Device(torch::kCPU);
+    else if (device_str == "cuda")
+        device = torch::Device(torch::kCUDA);
+
+    torch::jit::Module model = torch::jit::load(model_path, device);
+    model.eval();
+
+    std::cerr << "Loaded: " << model_path << " on "
+              << (device.is_cuda() ? "cuda" : "cpu") << "\n";
+
+    // Output stream
+    std::ofstream file_out;
+    std::ostream* out_ptr = &std::cout;
+    if (!out_path.empty()) {
+        // Create parent directories if needed (best-effort)
+        auto slash = out_path.rfind('/');
+        if (slash != std::string::npos) {
+            std::string dir = out_path.substr(0, slash);
+            (void)system(("mkdir -p " + dir).c_str());
+        }
+        file_out.open(out_path);
+        if (!file_out) {
+            std::cerr << "Error: cannot open " << out_path << "\n";
+            return 1;
+        }
+        out_ptr = &file_out;
+    }
+    std::ostream& out = *out_ptr;
+
+    // Extract model stem for header
+    std::string model_stem = model_path;
+    auto sl = model_stem.rfind('/');
+    if (sl != std::string::npos) model_stem = model_stem.substr(sl + 1);
+    auto dot = model_stem.rfind('.');
+    if (dot != std::string::npos) model_stem = model_stem.substr(0, dot);
+
+    out << "\n" << std::string(72, '=') << "\n"
+        << "  Model: " << model_stem
+        << "  (" << n_games << " games, seed=" << seed << ")\n"
+        << std::string(72, '=') << "\n";
+
+    std::mt19937 rng(seed);
+    for (int i = 1; i <= n_games; ++i)
+        play_and_print_game(model, device, rng, out, i);
+
+    if (!out_path.empty())
+        std::cerr << "Wrote " << out_path << "\n";
+
+    return 0;
+}

--- a/src/datagen/play_games.cpp
+++ b/src/datagen/play_games.cpp
@@ -213,34 +213,33 @@ static void play_and_print_game(torch::jit::Module& model, torch::Device device,
         lines.push_back("  Opp:  " + std::to_string(opp_sz) + " cards   Disc: " + disc_s);
 
         int chosen_mid;
-        std::vector<ScoredMove> top2;
+        std::vector<ScoredMove> topN;
 
         if (forced) {
             chosen_mid = legal[0];
         } else {
             auto scored = score_moves(model, device, game, cp, legal);
             chosen_mid  = scored[0].mid;
-            int n = std::min((int)scored.size(), 2);
-            for (int i = 0; i < n; ++i) top2.push_back(scored[i]);
+            int n = std::min((int)scored.size(), 10);
+            for (int i = 0; i < n; ++i) topN.push_back(scored[i]);
         }
 
         if (forced) {
             std::string mv = fmt_move(chosen_mid);
-            // pad to kMoveWidth
             while ((int)mv.size() < kMoveWidth) mv += ' ';
             lines.push_back("  ** " + mv + "  [forced]");
         } else {
-            for (int i = 0; i < (int)top2.size(); ++i) {
-                const auto& sm = top2[i];
-                std::string label = (i == 0) ? "#1" : "#2";
-                std::string mv    = fmt_move(sm.mid);
+            for (int i = 0; i < (int)topN.size(); ++i) {
+                const auto& sm = topN[i];
+                char label[8]; std::snprintf(label, sizeof(label), "#%-2d", i + 1);
+                std::string mv = fmt_move(sm.mid);
                 while ((int)mv.size() < kMoveWidth) mv += ' ';
                 char score_buf[64];
                 std::snprintf(score_buf, sizeof(score_buf),
                               "pt=%.2f vi=%.2f vn=%.2f w=%.2f",
                               sm.pt, sm.vi, sm.vn, sm.w);
                 std::string chosen_mark = (sm.mid == chosen_mid) ? "  ←" : "   ";
-                lines.push_back("  " + label + " " + mv + "  " + score_buf + chosen_mark);
+                lines.push_back("  " + std::string(label) + " " + mv + "  " + score_buf + chosen_mark);
             }
         }
 

--- a/src/simulation/nn_game_runner.cpp
+++ b/src/simulation/nn_game_runner.cpp
@@ -104,21 +104,22 @@ NNGameData NNGameRunner::run_game(std::mt19937& rng) const {
         int cp = game.current_player();
         auto legal = game.get_legal_moves();
 
-        // Tablebase: play out without recording turns
+        // Tablebase: play out without recording turns; both players use
+        // tablebase when applicable, policy otherwise (no random fallback).
         int tb_mid = tablebase_move_id(game, cp, legal);
         if (tb_mid >= 0) {
-            // Current player has a forcing line — play to end without recording
             game.apply_move(tb_mid);
             while (!game.is_over()) {
+                int cp2 = game.current_player();
                 auto rem = game.get_legal_moves();
-                int tb2 = tablebase_move_id(game, game.current_player(), rem);
+                int tb2 = tablebase_move_id(game, cp2, rem);
                 if (tb2 >= 0) {
                     game.apply_move(tb2);
+                } else if (rem.size() == 1) {
+                    game.apply_move(rem[0]);
                 } else {
-                    // Fall back to random for non-tablebase opponent replies
-                    int idx = std::uniform_int_distribution<int>(
-                        0, static_cast<int>(rem.size()) - 1)(rng);
-                    game.apply_move(rem[idx]);
+                    const auto& fn = (cp2 == 0) ? _p0_fn : _p1_fn;
+                    game.apply_move(fn(game, cp2, rem));
                 }
             }
             break;

--- a/src/simulation/nn_game_runner.h
+++ b/src/simulation/nn_game_runner.h
@@ -8,19 +8,20 @@
 #include <random>
 #include <vector>
 
-// Compact per-turn record for NN training. All fields reflect the game state
-// AFTER the move was applied (post-move hand, discard includes move cards).
-//
-// hand_at[n] / opp_at[n]:  bit r set iff the player/opponent-max has ≥(n+1) of rank r.
-// Python: count[r] = (at[0]>>r&1) + (at[1]>>r&1) + (at[2]>>r&1) + (at[3]>>r&1)
+// Per-turn record for NN training. All fields reflect game state AFTER the move.
+// hand_after / opp_counts: rank counts [0..12], ready for Python encode_exact/thermo.
+// trick_winner: 1 if this player won the trick, 0 if not (computed in C++ during sim).
 struct NNTurnData {
     int current_player;               // 0 or 1 (who played this move)
-    std::array<int, 13> move_enc;     // MOVE_TO_CARDS[move_id][0..12]
-    uint16_t hand_at[4];              // post-move player hand as HandBits (at1..at4)
-    uint16_t opp_at[4];              // post-move opponent max counts as HandBits
+    std::array<int, 13> move_enc;     // move rank counts (MOVE_TO_CARDS[move_id][0..12])
+    std::array<int, 13> hand_after;   // post-move player rank counts
+    std::array<int, 13> opp_counts;   // opponent max-possible rank counts
     float hint;                       // P(we win the trick) = 1-kHintTable; 0=pass, 1=flag
     bool flag;                        // !opponent_can_respond() post-move (logical deduction)
     bool pass_;                       // move_id == kPASS
+    bool vi_forced;                   // find_forced_win succeeds from hand_after w/ initiative
+    bool vn_forced;                   // vn=0: 1 card left, opp has <=1 card strictly below it
+    int8_t trick_winner;              // 1 if current_player won this trick, 0 otherwise
 };
 
 struct NNGameData {


### PR DESCRIPTION
## Summary

- **Pool-based batched eval** (`eval_nn_match`, `eval_nn_vs_classic`): run all 2×N game slots concurrently, single GPU forward pass per round — ~500× fewer round-trips, <1s per 400-deal eval
- **C++ trick label computation**: `NNTurnData` stores rank-count arrays + `trick_winner` (backfilled during simulation), eliminating a 40s Python for-loop that was bottlenecking dataset load
- **Streaming 1-epoch training loop** (`scripts/run_training_loop.sh`): fresh 200k games per generation, exponential generation mixing with `--mix-decay`, LR and temperature decay schedules
- **Bug fix in `compute_legal_moves`**: rank index off-by-3 for singles/pairs (Q/K/A were unbeatable), straight length mismatch in response logic — models trained before this commit are invalid
- **New binaries**: `play_games` (per-turn decision analysis), `eval_nn_vs_classic`, `eval_nn_match`
- **New scripts**: `scripts/analyze_ptrick_loss.py` (BCE breakdown by combo type), `scripts/sample_games.py`

## Test plan

- [x] `make test_core && ./bin/test_core` — all tests pass
- [x] All new binaries build cleanly
- [x] 6+ training generations ran end-to-end; gen4 achieved 67.9% vs greedy, 56.3% vs pimc(20)
- [x] Eval output parses correctly in training loop (WW%/split%/LL% columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)